### PR TITLE
feat: support .xlsm (macro-enabled Excel) files

### DIFF
--- a/src/DataTables.GeneratorCore/DataTableGenerator.cs
+++ b/src/DataTables.GeneratorCore/DataTableGenerator.cs
@@ -56,7 +56,13 @@ public sealed class DataTableGenerator
                         continue;
                     }
 
-                    if (!(fileName.EndsWith(".xlsx", StringComparison.Ordinal) || fileName.EndsWith(".xlsb", StringComparison.Ordinal) || fileName.EndsWith(".xls", StringComparison.Ordinal) || fileName.EndsWith(".csv", StringComparison.Ordinal)))
+                    // 支持的 Excel/CSV 扩展名：
+                    //   .xlsx — OOXML（Excel 2007+）
+                    //   .xlsm — OOXML 启用宏（结构与 xlsx 相同，仅多出 vbaProject.bin，NPOI XSSFWorkbook 完全兼容）
+                    //   .xlsb — Excel 二进制工作簿
+                    //   .xls  — 旧版 BIFF
+                    //   .csv  — 逗号分隔
+                    if (!(fileName.EndsWith(".xlsx", StringComparison.Ordinal) || fileName.EndsWith(".xlsm", StringComparison.Ordinal) || fileName.EndsWith(".xlsb", StringComparison.Ordinal) || fileName.EndsWith(".xls", StringComparison.Ordinal) || fileName.EndsWith(".csv", StringComparison.Ordinal)))
                     {
                         continue;
                     }


### PR DESCRIPTION
## 背景

下游项目（Cancer）大量配置表以 `.xlsm` 格式维护（含策划脚本的 VBA 宏模板），希望 dtgen 直接消费这些文件，避免每次手动另存为 `.xlsx`。

## 根因

即使调用方传入 `-patterns "*.xlsm"`，`DataTableGenerator.GenerateFile` 在 `Directory.EnumerateFiles` 之后还有一层硬编码的扩展名白名单：

```csharp
if (!(fileName.EndsWith(".xlsx") || fileName.EndsWith(".xlsb")
    || fileName.EndsWith(".xls")  || fileName.EndsWith(".csv")))
{
    continue;
}
```

`.xlsm` 文件在这里被静默丢弃，导致 `filePaths.Count == 0` 抛 `InvalidOperationException("Not found Excel files, ...")`。

## 改动

只在白名单里加 `.xlsm` 一项。其余管线无需改动——xlsm 与 xlsx 共用同一种 OOXML/SpreadsheetML 容器格式，差异只是 xlsm 多了 `vbaProject.bin`，NPOI 的 `XSSFWorkbook` 在读取工作表/单元格数据时会忽略它。

## 验证

- xlsm 文件用 NPOI `XSSFWorkbook(stream)` 打开行为与 xlsx 一致。
- 不影响现有的 xlsx/xlsb/xls/csv 路径。
- 默认 `searchPatterns` 未变；仅当用户主动传 `-patterns "*.xlsm"` 才会启用。

## 兼容性

- 完全向后兼容。
- 不引入新依赖。
- 不修改公共 API。