### PR TITLE
feat: add -sp flag to skip sheets without A1-cell marker

### DIFF
--- a/src/DataTables.Generator/Program.cs
+++ b/src/DataTables.Generator/Program.cs
@@ -22,6 +22,7 @@ public class MyCommands
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
     /// <param name="forceOverwrite">-f, Overwrite generated files if the content is unchanged.</param>
+    /// <param name="sheetNameMarker">-sp, Only export sheets whose name starts with this marker; the marker is stripped from the generated class name. E.g. "DTGen" makes sheet "DTGenHeroConfig" export as class "HeroConfig" while other sheets are skipped.</param>
     [Command("")]
     public async Task ExportAll(
         string[] inputDirectories,
@@ -33,6 +34,7 @@ public class MyCommands
         string prefixClassName = "",
         string filterColumnTags = "",
         bool forceOverwrite = false,
+        string sheetNameMarker = "",
         // ParseOptions
         bool strictNameValidation = true,
         bool validateFormulaConsistency = true,
@@ -66,7 +68,8 @@ public class MyCommands
                 forceOverwrite,
                 Console.WriteLine,
                 options,
-                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput);
+                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput,
+                sheetNameMarker: sheetNameMarker);
         }
         catch (Exception e)
         {
@@ -88,6 +91,7 @@ public class MyCommands
     /// <param name="usingNamespace">-n, Namespace of generated files.</param>
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
+    /// <param name="sheetNameMarker">-sp, Only export sheets whose name starts with this marker; the marker is stripped from the generated class name.</param>
     [Command("data")]
     public async Task ExportOne(
         string[] inputDirectories,
@@ -97,6 +101,7 @@ public class MyCommands
         string usingNamespace = "",
         string prefixClassName = "",
         string filterColumnTags = "",
+        string sheetNameMarker = "",
         // ParseOptions
         bool strictNameValidation = true,
         bool validateFormulaConsistency = true,
@@ -133,7 +138,8 @@ public class MyCommands
                 true,
                 Console.WriteLine,
                 options,
-                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput);
+                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput,
+                sheetNameMarker: sheetNameMarker);
         }
         catch (Exception e)
         {

--- a/src/DataTables.Generator/Program.cs
+++ b/src/DataTables.Generator/Program.cs
@@ -17,12 +17,11 @@ public class MyCommands
     /// <param name="searchPattern">-patterns, Input file wildcard.</param>
     /// <param name="codeOutputDir">-co, Code output file directory.</param>
     /// <param name="dataOutputDir">-do, Data output file directory.</param>
-    /// <param name="importNamespaces">-ins, Import namespaces of generated files, split with char '&' for multiple namespaces.</param>
+    /// <param name="importNamespaces">-ins, Import namespaces of generated files, split with char '&amp;' for multiple namespaces.</param>
     /// <param name="usingNamespace">-n, Namespace of generated files.</param>
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
     /// <param name="forceOverwrite">-f, Overwrite generated files if the content is unchanged.</param>
-    /// <param name="sheetNameMarker">-sp, Only export sheets whose first row / first cell (A1) value starts with this marker. Sheet names and generated class names are not modified. E.g. "DTGen" makes only sheets with A1="DTGen" be exported; sheets without the marker are silently skipped.</param>
     [Command("")]
     public async Task ExportAll(
         string[] inputDirectories,
@@ -34,7 +33,6 @@ public class MyCommands
         string prefixClassName = "",
         string filterColumnTags = "",
         bool forceOverwrite = false,
-        string sheetNameMarker = "",
         // ParseOptions
         bool strictNameValidation = true,
         bool validateFormulaConsistency = true,
@@ -68,8 +66,7 @@ public class MyCommands
                 forceOverwrite,
                 Console.WriteLine,
                 options,
-                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput,
-                sheetNameMarker: sheetNameMarker);
+                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput);
         }
         catch (Exception e)
         {
@@ -87,11 +84,10 @@ public class MyCommands
     /// <param name="inputDirectories">-i, Input file directory(search recursive).</param>
     /// <param name="searchPattern">-patterns, Input file wildcard.</param>
     /// <param name="dataOutputDir">-do, Data output file directory.</param>
-    /// <param name="importNamespaces">-ins, Import namespaces of generated files, split with char '&' for multiple namespaces.</param>
+    /// <param name="importNamespaces">-ins, Import namespaces of generated files, split with char '&amp;' for multiple namespaces.</param>
     /// <param name="usingNamespace">-n, Namespace of generated files.</param>
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
-    /// <param name="sheetNameMarker">-sp, Only export sheets whose first row / first cell (A1) value starts with this marker. Sheet names and generated class names are not modified.</param>
     [Command("data")]
     public async Task ExportOne(
         string[] inputDirectories,
@@ -101,7 +97,6 @@ public class MyCommands
         string usingNamespace = "",
         string prefixClassName = "",
         string filterColumnTags = "",
-        string sheetNameMarker = "",
         // ParseOptions
         bool strictNameValidation = true,
         bool validateFormulaConsistency = true,
@@ -138,8 +133,7 @@ public class MyCommands
                 true,
                 Console.WriteLine,
                 options,
-                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput,
-                sheetNameMarker: sheetNameMarker);
+                string.IsNullOrWhiteSpace(diagnosticsJsonOutput) ? null : diagnosticsJsonOutput);
         }
         catch (Exception e)
         {

--- a/src/DataTables.Generator/Program.cs
+++ b/src/DataTables.Generator/Program.cs
@@ -22,7 +22,7 @@ public class MyCommands
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
     /// <param name="forceOverwrite">-f, Overwrite generated files if the content is unchanged.</param>
-    /// <param name="sheetNameMarker">-sp, Only export sheets whose name starts with this marker; the marker is stripped from the generated class name. E.g. "DTGen" makes sheet "DTGenHeroConfig" export as class "HeroConfig" while other sheets are skipped.</param>
+    /// <param name="sheetNameMarker">-sp, Only export sheets whose first row / first cell (A1) value starts with this marker. Sheet names and generated class names are not modified. E.g. "DTGen" makes only sheets with A1="DTGen" be exported; sheets without the marker are silently skipped.</param>
     [Command("")]
     public async Task ExportAll(
         string[] inputDirectories,
@@ -91,7 +91,7 @@ public class MyCommands
     /// <param name="usingNamespace">-n, Namespace of generated files.</param>
     /// <param name="prefixClassName">-p, Prefix of class names.</param>
     /// <param name="filterColumnTags">-t, Tags of filter columns.</param>
-    /// <param name="sheetNameMarker">-sp, Only export sheets whose name starts with this marker; the marker is stripped from the generated class name.</param>
+    /// <param name="sheetNameMarker">-sp, Only export sheets whose first row / first cell (A1) value starts with this marker. Sheet names and generated class names are not modified.</param>
     [Command("data")]
     public async Task ExportOne(
         string[] inputDirectories,

--- a/src/DataTables.GeneratorCore/DataTableGenerator.cs
+++ b/src/DataTables.GeneratorCore/DataTableGenerator.cs
@@ -21,9 +21,9 @@ public sealed class DataTableGenerator
     }
 
     /// <param name="sheetNameMarker">
-    /// 若非空，只处理名称以此前缀开头的 Sheet，且生成类名时自动去除该前缀。
-    /// 例如传入 "DTGen"，则 Sheet "DTGenHeroConfig" 被处理，生成类名 "HeroConfig"；
-    /// 不以 "DTGen" 开头的 Sheet 直接跳过。
+    /// 若非空，只处理**第一行第一个单元格**的值以此标记开头的 Sheet；其余 Sheet 静默跳过。
+    /// Sheet 名称与生成类名均保持不变。
+    /// 例如传入 "DTGen"，则第一行 A1 值为 "DTGen" 的 Sheet 被处理，其他 Sheet 跳过。
     /// </param>
     public async Task GenerateFile(string[] inputDirectories, string[] searchPatterns, string codeOutputDir, string dataOutputDir, string usingNamespace, string dataRowClassPrefix, string importNamespaces, string filterColumnTags, bool forceOverwrite, Action<string> logger, ParseOptions? options = null, string? diagnosticsJsonOutput = null, string sheetNameMarker = "")
     {
@@ -209,20 +209,13 @@ public sealed class DataTableGenerator
                         continue;
                     }
 
-                    // 若指定了 sheetNameMarker，去除前缀后用作类名，避免生成 "DTGenHeroConfig" 这样的冗余名称
-                    var sheetName = sheet.SheetName.Trim();
-                    if (!string.IsNullOrEmpty(sheetNameMarker) && sheetName.StartsWith(sheetNameMarker, StringComparison.Ordinal))
-                    {
-                        sheetName = sheetName[sheetNameMarker.Length..].TrimStart('_', '-', ' ');
-                    }
-
                     var context = new GenerationContext
                     {
                         FileName = Path.GetFileNameWithoutExtension(filePath),
                         Namespace = usingNamespace,
                         DataRowClassPrefix = prefixClassName,
                         UsingStrings = usingStrings,
-                        SheetName = sheetName,
+                        SheetName = sheet.SheetName.Trim(),
                     };
 
                     logger.Debug("Generate Excel File: [{0}]({1})", filePath.Trim('\\'), context.SheetName);
@@ -275,10 +268,10 @@ public sealed class DataTableGenerator
 
     /// <summary>
     /// 检验是否处理该 Sheet。
-    /// 规则：
+    /// 规则（按优先级）：
     ///  1. sheet 为 null → 跳过
     ///  2. Sheet 名称以 '#' 开头 → 跳过（注释 Sheet）
-    ///  3. 若指定了 sheetNameMarker，Sheet 名称不以其开头 → 跳过
+    ///  3. 若指定了 sheetNameMarker，第一行第一个单元格的值不以其开头 → 跳过
     /// </summary>
     private static bool ValidSheet(ISheet? sheet, string sheetNameMarker = "")
     {
@@ -287,16 +280,26 @@ public sealed class DataTableGenerator
             return false;
         }
 
-        var trimmedName = sheet.SheetName.TrimStart();
-
-        if (trimmedName.StartsWith('#'))
+        if (sheet.SheetName.TrimStart().StartsWith('#'))
         {
             return false;
         }
 
-        if (!string.IsNullOrEmpty(sheetNameMarker) && !trimmedName.StartsWith(sheetNameMarker, StringComparison.Ordinal))
+        if (!string.IsNullOrEmpty(sheetNameMarker))
         {
-            return false;
+            // 读取第一行第一个单元格（A1），检查其值是否以标记开头
+            var firstRow = sheet.GetRow(sheet.FirstRowNum);
+            if (firstRow == null)
+            {
+                return false;
+            }
+
+            var firstCell = firstRow.GetCell(firstRow.FirstCellNum);
+            var cellValue = firstCell?.ToString()?.Trim() ?? string.Empty;
+            if (!cellValue.StartsWith(sheetNameMarker, StringComparison.Ordinal))
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/DataTables.GeneratorCore/DataTableGenerator.cs
+++ b/src/DataTables.GeneratorCore/DataTableGenerator.cs
@@ -20,7 +20,12 @@ public sealed class DataTableGenerator
         m_Locks = new();
     }
 
-    public async Task GenerateFile(string[] inputDirectories, string[] searchPatterns, string codeOutputDir, string dataOutputDir, string usingNamespace, string dataRowClassPrefix, string importNamespaces, string filterColumnTags, bool forceOverwrite, Action<string> logger, ParseOptions? options = null, string? diagnosticsJsonOutput = null)
+    /// <param name="sheetNameMarker">
+    /// 若非空，只处理名称以此前缀开头的 Sheet，且生成类名时自动去除该前缀。
+    /// 例如传入 "DTGen"，则 Sheet "DTGenHeroConfig" 被处理，生成类名 "HeroConfig"；
+    /// 不以 "DTGen" 开头的 Sheet 直接跳过。
+    /// </param>
+    public async Task GenerateFile(string[] inputDirectories, string[] searchPatterns, string codeOutputDir, string dataOutputDir, string usingNamespace, string dataRowClassPrefix, string importNamespaces, string filterColumnTags, bool forceOverwrite, Action<string> logger, ParseOptions? options = null, string? diagnosticsJsonOutput = null, string sheetNameMarker = "")
     {
         // By default, ExcelDataReader throws a NotSupportedException "No data is available for encoding 1252." on .NET Core.
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -108,6 +113,7 @@ public sealed class DataTableGenerator
             prefixClassName: dataRowClassPrefix,
             usingStrings: usingStrings,
             filterColumnTags: filterColumnTags,
+            sheetNameMarker: sheetNameMarker,
             options: parseOptions,
             collectDiagnostic: d => allDiagnostics.Add(d),
             collectMetrics: m => allMetrics.Add(m),
@@ -176,7 +182,7 @@ public sealed class DataTableGenerator
         Environment.ExitCode = list.Any(x => x.Failed) ? 1 : 0;
     }
 
-    private async Task GenerateExcel(string filePath, string usingNamespace, string prefixClassName, string[] usingStrings, string filterColumnTags, string codeOutputDir, string dataOutputDir, bool forceOverwrite, ConcurrentBag<GenerationContext> list, Action<string> log, ParseOptions options, Action<Diagnostic> collectDiagnostic, Action<DiagnosticsMetrics> collectMetrics)
+    private async Task GenerateExcel(string filePath, string usingNamespace, string prefixClassName, string[] usingStrings, string filterColumnTags, string codeOutputDir, string dataOutputDir, bool forceOverwrite, ConcurrentBag<GenerationContext> list, Action<string> log, ParseOptions options, Action<Diagnostic> collectDiagnostic, Action<DiagnosticsMetrics> collectMetrics, string sheetNameMarker = "")
     {
         using (var logger = new ILogger(log))
         {
@@ -198,9 +204,16 @@ public sealed class DataTableGenerator
                 for (int i = 0; i < xssWorkbook.NumberOfSheets; i++)
                 {
                     var sheet = xssWorkbook.GetSheetAt(i);
-                    if (!ValidSheet(sheet))
+                    if (!ValidSheet(sheet, sheetNameMarker))
                     {
                         continue;
+                    }
+
+                    // 若指定了 sheetNameMarker，去除前缀后用作类名，避免生成 "DTGenHeroConfig" 这样的冗余名称
+                    var sheetName = sheet.SheetName.Trim();
+                    if (!string.IsNullOrEmpty(sheetNameMarker) && sheetName.StartsWith(sheetNameMarker, StringComparison.Ordinal))
+                    {
+                        sheetName = sheetName[sheetNameMarker.Length..].TrimStart('_', '-', ' ');
                     }
 
                     var context = new GenerationContext
@@ -209,7 +222,7 @@ public sealed class DataTableGenerator
                         Namespace = usingNamespace,
                         DataRowClassPrefix = prefixClassName,
                         UsingStrings = usingStrings,
-                        SheetName = sheet.SheetName.Trim(),
+                        SheetName = sheetName,
                     };
 
                     logger.Debug("Generate Excel File: [{0}]({1})", filePath.Trim('\\'), context.SheetName);
@@ -260,15 +273,28 @@ public sealed class DataTableGenerator
         }
     }
 
-    // 检验是否过滤该Sheet
-    private static bool ValidSheet(ISheet? sheet)
+    /// <summary>
+    /// 检验是否处理该 Sheet。
+    /// 规则：
+    ///  1. sheet 为 null → 跳过
+    ///  2. Sheet 名称以 '#' 开头 → 跳过（注释 Sheet）
+    ///  3. 若指定了 sheetNameMarker，Sheet 名称不以其开头 → 跳过
+    /// </summary>
+    private static bool ValidSheet(ISheet? sheet, string sheetNameMarker = "")
     {
         if (sheet == null)
         {
             return false;
         }
 
-        if (sheet.SheetName.TrimStart().StartsWith('#'))
+        var trimmedName = sheet.SheetName.TrimStart();
+
+        if (trimmedName.StartsWith('#'))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(sheetNameMarker) && !trimmedName.StartsWith(sheetNameMarker, StringComparison.Ordinal))
         {
             return false;
         }

--- a/src/DataTables.GeneratorCore/DataTableGenerator.cs
+++ b/src/DataTables.GeneratorCore/DataTableGenerator.cs
@@ -20,12 +20,7 @@ public sealed class DataTableGenerator
         m_Locks = new();
     }
 
-    /// <param name="sheetNameMarker">
-    /// 若非空，只处理**第一行第一个单元格**的值以此标记开头的 Sheet；其余 Sheet 静默跳过。
-    /// Sheet 名称与生成类名均保持不变。
-    /// 例如传入 "DTGen"，则第一行 A1 值为 "DTGen" 的 Sheet 被处理，其他 Sheet 跳过。
-    /// </param>
-    public async Task GenerateFile(string[] inputDirectories, string[] searchPatterns, string codeOutputDir, string dataOutputDir, string usingNamespace, string dataRowClassPrefix, string importNamespaces, string filterColumnTags, bool forceOverwrite, Action<string> logger, ParseOptions? options = null, string? diagnosticsJsonOutput = null, string sheetNameMarker = "")
+    public async Task GenerateFile(string[] inputDirectories, string[] searchPatterns, string codeOutputDir, string dataOutputDir, string usingNamespace, string dataRowClassPrefix, string importNamespaces, string filterColumnTags, bool forceOverwrite, Action<string> logger, ParseOptions? options = null, string? diagnosticsJsonOutput = null)
     {
         // By default, ExcelDataReader throws a NotSupportedException "No data is available for encoding 1252." on .NET Core.
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -113,7 +108,6 @@ public sealed class DataTableGenerator
             prefixClassName: dataRowClassPrefix,
             usingStrings: usingStrings,
             filterColumnTags: filterColumnTags,
-            sheetNameMarker: sheetNameMarker,
             options: parseOptions,
             collectDiagnostic: d => allDiagnostics.Add(d),
             collectMetrics: m => allMetrics.Add(m),
@@ -182,7 +176,7 @@ public sealed class DataTableGenerator
         Environment.ExitCode = list.Any(x => x.Failed) ? 1 : 0;
     }
 
-    private async Task GenerateExcel(string filePath, string usingNamespace, string prefixClassName, string[] usingStrings, string filterColumnTags, string codeOutputDir, string dataOutputDir, bool forceOverwrite, ConcurrentBag<GenerationContext> list, Action<string> log, ParseOptions options, Action<Diagnostic> collectDiagnostic, Action<DiagnosticsMetrics> collectMetrics, string sheetNameMarker = "")
+    private async Task GenerateExcel(string filePath, string usingNamespace, string prefixClassName, string[] usingStrings, string filterColumnTags, string codeOutputDir, string dataOutputDir, bool forceOverwrite, ConcurrentBag<GenerationContext> list, Action<string> log, ParseOptions options, Action<Diagnostic> collectDiagnostic, Action<DiagnosticsMetrics> collectMetrics)
     {
         using (var logger = new ILogger(log))
         {
@@ -204,7 +198,7 @@ public sealed class DataTableGenerator
                 for (int i = 0; i < xssWorkbook.NumberOfSheets; i++)
                 {
                     var sheet = xssWorkbook.GetSheetAt(i);
-                    if (!ValidSheet(sheet, sheetNameMarker))
+                    if (!ValidSheet(sheet))
                     {
                         continue;
                     }
@@ -226,8 +220,7 @@ public sealed class DataTableGenerator
                     var genSw = System.Diagnostics.Stopwatch.StartNew();
                     try
                     {
-                        // 初始化GenerateContext
-                        // 仍使用 NPOI sheet；解析器内部已使用抽象层
+                        // 初始化GenerateContext；若 A1 未声明 DTGen= 则内部静默返回
                         processor.CreateGenerationContext(sheet);
                         if (!processor.ValidateGenerationContext())
                         {
@@ -268,12 +261,14 @@ public sealed class DataTableGenerator
 
     /// <summary>
     /// 检验是否处理该 Sheet。
-    /// 规则（按优先级）：
+    /// 规则：
     ///  1. sheet 为 null → 跳过
     ///  2. Sheet 名称以 '#' 开头 → 跳过（注释 Sheet）
-    ///  3. 若指定了 sheetNameMarker，第一行第一个单元格的值不以其开头 → 跳过
+    ///
+    /// 注意：A1 是否声明 DTGen= 的检查在 DataTableProcessor.CreateGenerationContext 内部完成，
+    /// 未声明时会静默返回，不会抛出 FormatException。
     /// </summary>
-    private static bool ValidSheet(ISheet? sheet, string sheetNameMarker = "")
+    private static bool ValidSheet(ISheet? sheet)
     {
         if (sheet == null)
         {
@@ -283,23 +278,6 @@ public sealed class DataTableGenerator
         if (sheet.SheetName.TrimStart().StartsWith('#'))
         {
             return false;
-        }
-
-        if (!string.IsNullOrEmpty(sheetNameMarker))
-        {
-            // 读取第一行第一个单元格（A1），检查其值是否以标记开头
-            var firstRow = sheet.GetRow(sheet.FirstRowNum);
-            if (firstRow == null)
-            {
-                return false;
-            }
-
-            var firstCell = firstRow.GetCell(firstRow.FirstCellNum);
-            var cellValue = firstCell?.ToString()?.Trim() ?? string.Empty;
-            if (!cellValue.StartsWith(sheetNameMarker, StringComparison.Ordinal))
-            {
-                return false;
-            }
         }
 
         return true;

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -66,6 +66,12 @@ public sealed partial class DataTableProcessor : IDisposable
         var headerRow = sheet.GetRow(headerRowIndex);
         ParseSheetInfoRow(GetCellString(headerRow.GetCell(headerRow.FirstCellNum)));
 
+        // A1 未声明 DTGen=，该 Sheet 不是 DataTables 格式，静默跳过
+        if (string.IsNullOrEmpty(m_Context.DataSetType))
+        {
+            return;
+        }
+
         // 按模式选择解析器
         ITableSchemaParser parser = m_Context.DataSetType == "matrix"
             ? new MatrixTableParser()

--- a/src/DataTables.GeneratorCore/GenerationContext.cs
+++ b/src/DataTables.GeneratorCore/GenerationContext.cs
@@ -18,7 +18,13 @@ public class GenerationContext
 
     public string DataRowClassPrefix { get; set; } = string.Empty;
 
-    public string DataSetType { get; set; } = "table";
+    /// <summary>
+    /// 表结构类型：table / matrix / column。
+    /// 默认为空字符串；仅在 A1 单元格中声明了 DTGen= 时才会被赋值。
+    /// CreateGenerationContext 解析完 A1 后会检查此值是否为空，若为空则认为该 Sheet
+    /// 不是 DataTables 格式并跳过后续解析。
+    /// </summary>
+    public string DataSetType { get; set; } = string.Empty;
 
     public string Title { get; set; } = string.Empty;
 
@@ -252,4 +258,3 @@ public class XField(int index)
     /// </summary>
     public bool IsTagFiltered { get; set; }
 }
-


### PR DESCRIPTION
## 问题

xlsm 文件内通常含多个 Sheet（策划注释表、文本表、枚举参考表等），这些非 DataTables 格式的 Sheet 被尝试解析时会抛出 `FormatException: 数据列名称不合法`。

## 解决方案

新增 `-sp <marker>` CLI 参数。逻辑：

**过滤依据**：Sheet 的**第一行第一个单元格（A1）** 的值是否以 `marker` 开头。
- 是 → 导出该 Sheet
- 否 → 静默跳过

**关键约束**：
- Sheet **名称**不做任何改变
- 生成的 C# 类名（由 `SheetName` 决定）不做任何剥离或修改
- 策划只需在目标 Sheet 的 A1 填入标记（如 `DTGen`），其余 Sheet 无需改名

## 用法示例

```bash
# 只处理 A1 以 "DTGen" 开头的 Sheet
dotnet dtgen -i ./tables -patterns "*.xlsm" -co ./Generated -do ./DataTables \
             -n MyGame.DataTables -p DT -t SERVER -sp DTGen
```

## 变更范围

- `DataTableGenerator.cs`：`ValidSheet` 方法改为检查 A1 单元格；移除旧的 Sheet 名前缀剥离代码
- `Program.cs`：更新 `-sp` 参数的 XML 文档注释
