### PR TITLE
fix: allow Unicode letters in column names (NameRegex)

### DIFF
--- a/src/DataTables.GeneratorCore/RowTableParser.cs
+++ b/src/DataTables.GeneratorCore/RowTableParser.cs
@@ -6,7 +6,10 @@ namespace DataTables.GeneratorCore;
 
 public sealed class RowTableParser : ITableSchemaParser
 {
-	private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
+	// \p{L} matches any Unicode letter (including CJK, Cyrillic, etc.)
+	// \p{N} matches any Unicode number digit
+	// This aligns with C# identifier rules which also permit Unicode letters.
+	private static readonly Regex NameRegex = new Regex(@"^[\p{L}_][\p{L}\p{N}_]*$");
 
     public int Parse(ISheetReader sheet, GenerationContext context, ParseOptions options, DiagnosticsCollector diagnostics)
 	{
@@ -60,4 +63,3 @@ public sealed class RowTableParser : ITableSchemaParser
 		return typeRow + 1;
 	}
 }
-


### PR DESCRIPTION
## 问题

`RowTableParser` 中的 `NameRegex` 仅允许 ASCII 字母：

```csharp
private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
```

当列名包含中文（或其他 Unicode 字母）时，如 `Name文本`，会抛出：

```
System.FormatException: 数据列名称不合法: Name文本
```

## 根因

`[A-Za-z0-9_]` 只匹配 ASCII，不匹配任何 Unicode 字母（汉字属于 Unicode 类别 `Lo`）。

## 修复

改用 Unicode 属性转义：

```csharp
private static readonly Regex NameRegex = new Regex(@"^[\p{L}_][\p{L}\p{N}_]*$");
```

- `\p{L}` = 所有 Unicode 字母（包括中文、日文、俄文等）
- `\p{N}` = 所有 Unicode 数字
- 与 C# 标识符规范一致（C# 本身允许 Unicode 字母作为标识符）

**向后兼容**：所有原来合法的 ASCII 列名仍然合法。