### PR TITLE
Centralize data type parsing, normalize signatures and improve diagnostics

### DIFF
--- a/src/DataTables.GeneratorCore/DataTableProcessor.DataProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.DataProcessor.cs
@@ -21,6 +21,12 @@ public sealed partial class DataTableProcessor
             get;
         }
 
+        public DataTypeDescriptor? TypeDescriptor
+        {
+            get;
+            internal set;
+        }
+
         protected string Tabs(int depth)
         {
             return new string(' ', 4 * (depth + 2));

--- a/src/DataTables.GeneratorCore/DataTableProcessor.DataProcessorUtility.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.DataProcessorUtility.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace DataTables.GeneratorCore;
@@ -9,6 +11,7 @@ public sealed partial class DataTableProcessor
     private static class DataProcessorUtility
     {
         private static readonly ConcurrentDictionary<string, DataProcessor> s_DataProcessors = new ConcurrentDictionary<string, DataProcessor>(StringComparer.Ordinal);
+        private static readonly List<string> s_SupportedTypeStrings = new();
 
         static DataProcessorUtility()
         {
@@ -31,165 +34,63 @@ public sealed partial class DataTableProcessor
 
                     foreach (string typeString in dataProcessor.GetTypeStrings())
                     {
-                        s_DataProcessors.TryAdd(typeString.ToLowerInvariant(), dataProcessor);
+                        var key = NormalizeCacheKey(typeString);
+                        s_DataProcessors.TryAdd(key, dataProcessor);
+                        if (!s_SupportedTypeStrings.Contains(key, StringComparer.Ordinal))
+                        {
+                            s_SupportedTypeStrings.Add(key);
+                        }
                     }
                 }
             }
+
+            s_SupportedTypeStrings.AddRange(["array<T>", "map<K,V>", "json<T>", "enum<T>", "custom<T>"]);
         }
 
         public static DataProcessor GetDataProcessor(string type)
         {
-            if (type == null)
+            var descriptor = DataTypeParser.Parse(type, GetSupportedTypeStrings());
+            if (s_DataProcessors.TryGetValue(descriptor.NormalizedSignature, out var dataProcessor))
             {
-                type = string.Empty;
-            }
-
-            DataProcessor? dataProcessor;
-            if (s_DataProcessors.TryGetValue(type.ToLowerInvariant(), out dataProcessor))
-            {
+                dataProcessor.TypeDescriptor = descriptor;
                 return dataProcessor;
             }
-            else if (type.StartsWith("enum", StringComparison.InvariantCultureIgnoreCase))
+
+            var name = descriptor.Name.ToLowerInvariant();
+            DataProcessor created = name switch
             {
-                var str1 = FindGenericString(type);
-                if (s_DataProcessors.TryGetValue($"enum<{str1}>", out var abc))
-                {
-                    return abc;
-                }
-                else
-                {
-                    abc = new EnumProcessor(str1);
-                    foreach (var ts in abc.GetTypeStrings())
-                    {
-                        s_DataProcessors.TryAdd(ts, abc);
-                    }
-                    return abc;
-                }
-            }
-            else if (type.StartsWith("array", StringComparison.InvariantCultureIgnoreCase))
+                "enum" => new EnumProcessor(descriptor.Arguments[0].Name),
+                "array" => new ArrayDataProcessor(GetDataProcessor(descriptor.Arguments[0].NormalizedSignature)),
+                "map" => new MapDataProcessor(GetDataProcessor(descriptor.Arguments[0].NormalizedSignature), GetDataProcessor(descriptor.Arguments[1].NormalizedSignature)),
+                "json" => new JSONProcessor(descriptor.Arguments[0].Name),
+                "custom" => new CustomizeProcessor(descriptor.Arguments[0].Name),
+                _ => throw new DataTypeParseException(type ?? string.Empty, 0, "当前支持的类型之一", GetSupportedTypeStrings()),
+            };
+
+            created.TypeDescriptor = descriptor;
+            foreach (var ts in created.GetTypeStrings())
             {
-                var str1 = FindGenericString(type);
-
-                if (s_DataProcessors.TryGetValue($"array<{str1}>", out var abc))
-                {
-                    return abc;
-                }
-                else
-                {
-                    var keyProcessor = GetDataProcessor(str1);
-
-                    abc = new ArrayDataProcessor(keyProcessor);
-                    foreach (var ts in abc.GetTypeStrings())
-                    {
-                        if (s_DataProcessors.ContainsKey(ts))
-                        {
-                            continue;
-                        }
-
-                        s_DataProcessors.TryAdd(ts, abc);
-                    }
-                    return abc;
-                }
+                s_DataProcessors.TryAdd(NormalizeCacheKey(ts), created);
             }
-            else if (type.StartsWith("map", StringComparison.InvariantCultureIgnoreCase))
-            {
-                var str1 = FindGenericString(type);
-
-                var index = FindSplitCharIndex(str1);
-                if (index == -1)
-                {
-                    throw new Exception(string.Format("Not supported data processor type '{0}'.", type));
-                }
-
-                var keyTypeStr = str1.Substring(0, index).Trim();
-                var valueTypeStr = str1.Substring(index + 1).Trim();
-
-                if (s_DataProcessors.TryGetValue($"map<{keyTypeStr},{valueTypeStr}>", out var abc))
-                {
-                    return abc;
-                }
-                else
-                {
-                    var keyProcessor = GetDataProcessor(keyTypeStr);
-                    var valueProcessor = GetDataProcessor(valueTypeStr);
-
-                    abc = new MapDataProcessor(keyProcessor, valueProcessor);
-                    foreach (var ts in abc.GetTypeStrings())
-                    {
-                        s_DataProcessors.TryAdd(ts, abc);
-                    }
-                    return abc;
-                }
-            }
-            else if (type.StartsWith("json", StringComparison.InvariantCultureIgnoreCase))
-            {
-                var str1 = FindGenericString(type);
-
-                if (s_DataProcessors.TryGetValue($"json<{str1}>", out var abc))
-                {
-                    return abc;
-                }
-                else
-                {
-                    abc = new JSONProcessor(str1);
-                    foreach (var ts in abc.GetTypeStrings())
-                    {
-                        s_DataProcessors.TryAdd(ts, abc);
-                    }
-                    return abc;
-                }
-            }
-            else if (type.StartsWith("custom", StringComparison.InvariantCultureIgnoreCase))
-            {
-                var str1 = FindGenericString(type);
-
-                if (s_DataProcessors.TryGetValue($"custom<{str1}>", out var abc))
-                {
-                    return abc;
-                }
-                else
-                {
-                    abc = new CustomizeProcessor(str1);
-                    foreach (var ts in abc.GetTypeStrings())
-                    {
-                        s_DataProcessors.TryAdd(ts, abc);
-                    }
-                    return abc;
-                }
-            }
-
-            throw new Exception(string.Format("Not supported data processor type '{0}'.", type));
+            s_DataProcessors.TryAdd(descriptor.NormalizedSignature, created);
+            return created;
         }
 
-        public static string FindGenericString(string type)
+        public static IReadOnlyList<string> GetSupportedTypeStrings()
         {
-            return type.Substring(type.IndexOf('<') + 1, type.LastIndexOf('>') - type.IndexOf('<') - 1).Trim();
+            return s_SupportedTypeStrings.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToArray();
         }
 
-        private static int FindSplitCharIndex(string str1)
+        private static string NormalizeCacheKey(string type)
         {
-            var index = -1;
-            var depth = 0;
-            for (int i = 0; i < str1.Length; i++)
+            try
             {
-                if (str1[i] == '<')
-                {
-                    depth++;
-                    continue;
-                }
-                else if (str1[i] == '>')
-                {
-                    depth--;
-                    continue;
-                }
-                else if (str1[i] == ',' && depth == 0)
-                {
-                    index = i;
-                    break;
-                }
+                return DataTypeParser.NormalizeSignature(type, Array.Empty<string>());
             }
-
-            return index;
+            catch (DataTypeParseException)
+            {
+                return (type ?? string.Empty).Trim().ToLowerInvariant();
+            }
         }
     }
 }

--- a/src/DataTables.GeneratorCore/DataTableProcessor.DataTypeParser.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.DataTypeParser.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DataTables.GeneratorCore;
+
+public sealed partial class DataTableProcessor
+{
+    public sealed class DataTypeDescriptor
+    {
+        public DataTypeDescriptor(string originalText, string normalizedSignature, string name, IReadOnlyList<DataTypeDescriptor> arguments)
+        {
+            OriginalText = originalText;
+            NormalizedSignature = normalizedSignature;
+            Name = name;
+            Arguments = arguments;
+        }
+
+        public string OriginalText { get; }
+        public string NormalizedSignature { get; }
+        public string Name { get; }
+        public IReadOnlyList<DataTypeDescriptor> Arguments { get; }
+    }
+
+    public sealed class DataTypeParseException : FormatException
+    {
+        public DataTypeParseException(string originalType, int position, string expectedFormat, IReadOnlyList<string> supportedTypes)
+            : base(BuildMessage(originalType, position, expectedFormat, supportedTypes))
+        {
+            OriginalType = originalType;
+            Position = position;
+            ExpectedFormat = expectedFormat;
+            SupportedTypes = supportedTypes;
+        }
+
+        public string OriginalType { get; }
+        public int Position { get; }
+        public string ExpectedFormat { get; }
+        public IReadOnlyList<string> SupportedTypes { get; }
+
+        private static string BuildMessage(string originalType, int position, string expectedFormat, IReadOnlyList<string> supportedTypes)
+        {
+            return $"类型解析失败: OriginalType='{originalType}', Position={position}, ExpectedFormat='{expectedFormat}', SupportedTypes=[{string.Join(", ", supportedTypes)}]";
+        }
+    }
+
+    private static class DataTypeParser
+    {
+        private static readonly Dictionary<string, string> s_Aliases = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["int32"] = "int",
+            ["system.int32"] = "int",
+            ["single"] = "float",
+            ["system.single"] = "float",
+            ["datetime"] = "DateTime",
+            ["system.datetime"] = "DateTime",
+            ["a"] = "array",
+            ["m"] = "map",
+            ["e"] = "enum",
+        };
+
+        public static DataTypeDescriptor Parse(string? type, IReadOnlyList<string> supportedTypes)
+        {
+            var original = type ?? string.Empty;
+            var parser = new Parser(original, supportedTypes);
+            return parser.Parse();
+        }
+
+        public static string NormalizeSignature(string? type, IReadOnlyList<string> supportedTypes) => Parse(type, supportedTypes).NormalizedSignature;
+
+        private sealed class Parser
+        {
+            private readonly string m_Text;
+            private readonly IReadOnlyList<string> m_SupportedTypes;
+            private int m_Position;
+
+            public Parser(string text, IReadOnlyList<string> supportedTypes)
+            {
+                m_Text = text;
+                m_SupportedTypes = supportedTypes;
+            }
+
+            public DataTypeDescriptor Parse()
+            {
+                SkipWhitespace();
+                var result = ParseType();
+                SkipWhitespace();
+                if (m_Position != m_Text.Length)
+                {
+                    Fail("类型结尾，或泛型格式 array<T>、map<K,V>、json<T>、enum<T>");
+                }
+                return result;
+            }
+
+            private DataTypeDescriptor ParseType()
+            {
+                SkipWhitespace();
+                var start = m_Position;
+                var name = ParseName();
+                if (name.Length == 0)
+                {
+                    Fail("类型名称");
+                }
+
+                var canonicalName = NormalizeName(name);
+                SkipWhitespace();
+                if (m_Position < m_Text.Length && m_Text[m_Position] == '<')
+                {
+                    m_Position++;
+                    var args = new List<DataTypeDescriptor>();
+                    while (true)
+                    {
+                        args.Add(ParseType());
+                        SkipWhitespace();
+                        if (m_Position < m_Text.Length && m_Text[m_Position] == ',')
+                        {
+                            m_Position++;
+                            continue;
+                        }
+                        if (m_Position < m_Text.Length && m_Text[m_Position] == '>')
+                        {
+                            m_Position++;
+                            break;
+                        }
+                        Fail(args.Count == 1 ? "',' 或 '>'" : "'>'");
+                    }
+
+                    ValidateGeneric(canonicalName, args.Count, start);
+                    var signature = $"{canonicalName.ToLowerInvariant()}<{string.Join(",", args.Select(a => a.NormalizedSignature))}>";
+                    return new DataTypeDescriptor(m_Text, signature, canonicalName, args);
+                }
+
+                var normalized = canonicalName == "DateTime" ? "datetime" : canonicalName.ToLowerInvariant();
+                return new DataTypeDescriptor(m_Text, normalized, canonicalName, Array.Empty<DataTypeDescriptor>());
+            }
+
+            private string ParseName()
+            {
+                var start = m_Position;
+                while (m_Position < m_Text.Length)
+                {
+                    var c = m_Text[m_Position];
+                    if (char.IsLetterOrDigit(c) || c == '_' || c == '.') m_Position++;
+                    else break;
+                }
+                return m_Text[start..m_Position];
+            }
+
+            private string NormalizeName(string name) => s_Aliases.TryGetValue(name, out var alias) ? alias : name;
+
+            private void ValidateGeneric(string name, int argumentCount, int position)
+            {
+                var lower = name.ToLowerInvariant();
+                var ok = lower switch
+                {
+                    "array" => argumentCount == 1,
+                    "json" => argumentCount == 1,
+                    "enum" => argumentCount == 1,
+                    "custom" => argumentCount == 1,
+                    "map" => argumentCount == 2,
+                    _ => false,
+                };
+                if (!ok)
+                {
+                    m_Position = position;
+                    Fail("array<T>、map<K,V>、json<T>、enum<T> 或 custom<T>");
+                }
+            }
+
+            private void SkipWhitespace()
+            {
+                while (m_Position < m_Text.Length && char.IsWhiteSpace(m_Text[m_Position])) m_Position++;
+            }
+
+            private void Fail(string expected) => throw new DataTypeParseException(m_Text, m_Position, expected, m_SupportedTypes);
+        }
+    }
+}

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -459,6 +459,7 @@ public sealed partial class DataTableProcessor : IDisposable
 
             var text = GetCellString(row.GetCell(field.Index));
             field.TypeName = text;
+            field.TypeCell = GetRowColString(row.RowNum, field.Index);
         }
     }
 
@@ -611,7 +612,7 @@ public sealed partial class DataTableProcessor : IDisposable
             {
                 if (field.IsIgnore) { continue; }
 
-                var processor = DataProcessorUtility.GetDataProcessor(field.TypeName);
+                var processor = GetDataProcessorWithDiagnostics(field);
                 try
                 {
                     processor.WriteToStream(writer, GetCellString(row.GetCell(field.Index)));
@@ -626,13 +627,28 @@ public sealed partial class DataTableProcessor : IDisposable
         }
     }
 
+
+    private DataProcessor GetDataProcessorWithDiagnostics(XField field)
+    {
+        try
+        {
+            return DataProcessorUtility.GetDataProcessor(field.TypeName);
+        }
+        catch (DataTypeParseException ex)
+        {
+            var cell = string.IsNullOrEmpty(field.TypeCell) ? string.Empty : field.TypeCell;
+            m_Diagnostics.Error(m_Context.FileName, m_Context.SheetName, cell, $"字段 '{field.Name}' 类型 '{field.TypeName}' 解析失败: {ex.Message}");
+            throw new FormatException($"类型解析失败: File='{m_Context.FileName}', Sheet='{m_Context.SheetName}', Field='{field.Name}', TypeCell='{cell}', FieldType='{field.TypeName}'. {ex.Message}", ex);
+        }
+    }
+
     private int WriteColumnBytes(BinaryWriter writer, ISheet sheet, int columnIndex)
     {
         foreach (var field in m_Context.Fields)
         {
             if (field.IsIgnore) { continue; }
 
-            var processor = DataProcessorUtility.GetDataProcessor(field.TypeName);
+            var processor = GetDataProcessorWithDiagnostics(field);
             try
             {
                 var row = sheet.GetRow(field.Index);
@@ -716,6 +732,7 @@ public sealed partial class DataTableProcessor : IDisposable
             // C:Type
             var typeText = GetCellString(row.GetCell(row.FirstCellNum + 2));
             field.TypeName = typeText;
+            field.TypeCell = GetRowColString(r, row.FirstCellNum + 2);
 
             fields.Add(field);
         }

--- a/src/DataTables.GeneratorCore/GenerationContext.cs
+++ b/src/DataTables.GeneratorCore/GenerationContext.cs
@@ -234,6 +234,11 @@ public class XField(int index)
     public string TypeName { get; set; } = string.Empty;
 
     /// <summary>
+    /// 字段类型所在单元格（例如 C3），用于诊断定位。
+    /// </summary>
+    public string TypeCell { get; set; } = string.Empty;
+
+    /// <summary>
     /// 字段名
     /// </summary>
     public string Name { get; set; } = string.Empty;

--- a/src/DataTables.GeneratorCore/Schema/ParserUtils.cs
+++ b/src/DataTables.GeneratorCore/Schema/ParserUtils.cs
@@ -8,6 +8,24 @@ internal static class ParserUtils
 {
 	private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
 
+	public static string GetCellAddress(int row, int col)
+	{
+		return $"{ConvertToColumnName(col)}{row + 1}";
+	}
+
+	private static string ConvertToColumnName(int col)
+	{
+		var dividend = col + 1;
+		var columnName = string.Empty;
+		while (dividend > 0)
+		{
+			var modulo = (dividend - 1) % 26;
+			columnName = Convert.ToChar('A' + modulo) + columnName;
+			dividend = (dividend - modulo) / 26;
+		}
+		return columnName;
+	}
+
 	public static int FindNextValidRowIndex(ISheet sheet, int startExclusive)
 	{
 		for (int i = startExclusive + 1; i <= sheet.LastRowNum; i++)
@@ -202,6 +220,7 @@ internal static class ParserUtils
 
 			var typeText = GetCellString(row.GetCell(row.FirstCellNum + 2));
 			field.TypeName = typeText;
+			field.TypeCell = GetCellAddress(r, row.FirstCellNum + 2);
 
 			fields.Add(field);
 		}

--- a/src/DataTables.GeneratorCore/Schema/RowTableParser.cs
+++ b/src/DataTables.GeneratorCore/Schema/RowTableParser.cs
@@ -55,6 +55,7 @@ public sealed class RowTableParser : ITableSchemaParser
 		{
 			if (field.IsIgnore) continue;
 			field.TypeName = (typeRowObj.GetCell(field.Index)?.GetString() ?? string.Empty).Trim();
+            field.TypeCell = ParserUtils.GetCellAddress(typeRow, field.Index);
 		}
 
 		return typeRow + 1;


### PR DESCRIPTION
### Motivation
- Provide a structured description for parsed field types so processors can expose canonical signatures and generic arguments (`DataTypeDescriptor`).
- Move generic-type parsing logic out of scattered conditionals into a single parser to support `array<T>`, `map<K,V>`, `json<T>`, `enum<T>` and `custom<T>` and to centralize alias handling and validation.
- Surface structured parse errors so the generator can report type issues with file/sheet/field and precise type-cell location for easier debugging.

### Description
- Added `DataTypeDescriptor` and `DataTypeParseException` and implemented `DataTypeParser` that parses/validates generic type signatures, normalizes aliases (e.g. `int32 -> int`, `single -> float`, `datetime -> DateTime`, short aliases `a/m/e`), and produces canonical lowercase signatures like `array<int>` or `map<string,int>` (`src/DataTables.GeneratorCore/DataTableProcessor.DataTypeParser.cs`).
- Extended `DataProcessor` with a `TypeDescriptor` property so created/resolved processors carry parsed type metadata (`src/DataTables.GeneratorCore/DataTableProcessor.DataProcessor.cs`).
- Refactored `DataProcessorUtility.GetDataProcessor` to use `DataTypeParser` and a normalized cache-key policy (`NormalizeCacheKey`) and to build complex processors from parsed descriptors instead of ad-hoc string splitting; added `GetSupportedTypeStrings` to enumerate supported signatures (`src/DataTables.GeneratorCore/DataTableProcessor.DataProcessorUtility.cs`).
- Added field type-cell tracking by introducing `TypeCell` on `XField`, `ParserUtils.GetCellAddress`/`ConvertToColumnName`, and setting `TypeCell` in schema parsers (`RowTableParser`/`ParserUtils`) and the main processor, enabling diagnostics to point to the exact cell (`src/DataTables.GeneratorCore/GenerationContext.cs`, `src/DataTables.GeneratorCore/Schema/ParserUtils.cs`, `src/DataTables.GeneratorCore/Schema/RowTableParser.cs`, `src/DataTables.GeneratorCore/DataTableProcessor.cs`).
- Added `GetDataProcessorWithDiagnostics` wrapper to catch `DataTypeParseException`, record a structured error into `DiagnosticsCollector` (file/sheet/cell/message) and rethrow a `FormatException` with context so type parsing failures are reported with file, sheet, field name, field type and cell address (`src/DataTables.GeneratorCore/DataTableProcessor.cs`).

### Testing
- Attempted to run `dotnet build DataTables.sln` but the environment does not have the `dotnet` SDK installed so a build could not be executed (build not run).
- No automated unit tests were run in this environment; runtime compilation and test execution should be performed in a CI or local environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b07096f90833183c01f1e894a49cf)