### PR TITLE
Update Unity license secret in GitHub workflows

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_LICENSE: ${{ secrets.UNITY_SERIAL }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LINCESE }}
         with:
           projectPath: src/DataTables.Unity
           unityVersion: ${{ matrix.unity }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_LICENSE: ${{ secrets.UNITY_SERIAL }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LINCESE }}
           UNITY_PACKAGE_VERSION: ${{ inputs.tag }}
         with:
           projectPath: src/DataTables.Unity


### PR DESCRIPTION
### Motivation
- The previous secret name `UNITY_SERIAL` is no longer valid for ChronosGames Unity builds, so workflows must reference the updated `UNITY_LINCESE` secret.

### Description
- Replace `secrets.UNITY_SERIAL` with `secrets.UNITY_LINCESE` in `/.github/workflows/build-debug.yml` and `/.github/workflows/build-release.yml` so the Unity builder actions receive the correct license secret.

### Testing
- Confirmed there are no remaining `UNITY_SERIAL` occurrences with `rg --hidden -n "UNITY_SERIAL" . -S || true` and that replacements appear with `rg --hidden -n "UNITY_LINCESE" . -S || true`, and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b18cf531083319c21c11324147da1)