### PR TITLE
Add structured binary data table header and schema-hash validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,3 +733,24 @@ This library is under the MIT License.
 - 📢 向其他开发者推荐
 
 **感谢使用 DataTables！享受现代化高性能的开发体验！** 🚀
+
+## Binary format upgrade and compatibility
+
+Starting with binary format version 3, generated `.bytes` files use a structured header before the row payload:
+
+1. `Signature` (`DTABLE`)
+2. `FormatVersion`
+3. `SchemaHash`
+4. `GeneratorVersion`
+5. `TableFullName`
+6. `RowCount`
+7. `Flags`
+
+The schema hash is calculated during generation from the effective exported schema: table type, table full name, and each non-ignored field's name, type, and order. Runtime loading validates the `.bytes` schema hash against the hash embedded in the generated table class, so a mismatch clearly indicates that the generated C# code and binary data were not produced from the same table schema.
+
+Compatibility window:
+
+* Format versions `1` and `2` remain readable through the legacy path (`Signature`, `FormatVersion`, `RowCount`, then row payload) and do not perform schema-hash validation.
+* Format version `3` and later use the structured header and require schema validation.
+* Runtimes reject files with a format version newer than the maximum version they support. When upgrading format versions, regenerate both the C# table code and `.bytes` assets together, deploy the new runtime first, and keep legacy readers only for the documented compatibility window.
+* `Flags` is reserved for payload features such as compression, encryption, or an embedded default-value table. Unknown non-zero flags are rejected by the runtime until explicit support is added.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [🏆 性能基准](#-%E6%80%A7%E8%83%BD%E5%9F%BA%E5%87%86)
   - [📜 License](#-license)
   - [🌟 支持项目](#-%E6%94%AF%E6%8C%81%E9%A1%B9%E7%9B%AE)
+  - [Binary format upgrade and compatibility](#binary-format-upgrade-and-compatibility)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
@@ -59,7 +59,9 @@ namespace DataTables.GeneratorCore
             
             #line default
             #line hidden
-            this.Write(">\r\n{\r\n    ");
+            this.Write(">\r\n{\r\n    public override ulong SchemaHash => ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(DataTableSchemaHash.Compute(GenerationContext)));
+            this.Write("UL;\r\n\r\n    ");
             
             this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(GenerationContext.MatrixDefaultValue) ? string.Empty : "protected override " + BuildTypeString(kValue) + " DefaultValue => " + BuildTypeValueString(kValue, GenerationContext.MatrixDefaultValue) + ";" + Environment.NewLine));
             

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -13,7 +13,7 @@ public sealed partial class DataTableProcessor : IDisposable
 {
     private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
 
     private readonly GenerationContext m_Context;
     private readonly IFormulaEvaluator m_FormulaEvaluator;

--- a/src/DataTables.GeneratorCore/DataTableTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataTableTemplate.cs
@@ -31,6 +31,8 @@ public partial class DataTableTemplate
         if (!string.IsNullOrEmpty(Namespace)) { WL($"namespace {Namespace}"); WL("{"); }
         WL($"public sealed partial class {GenerationContext.DataTableClassName} : DataTable<{GenerationContext.DataRowClassName}>");
         WL("{");
+        WL($"    public override ulong SchemaHash => {DataTableSchemaHash.Compute(GenerationContext)}UL;");
+        WL();
         var dictIndex = 1;
         foreach (var index in GenerationContext.IndexDefinitions)
         {

--- a/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
@@ -9,7 +9,8 @@ namespace DataTables.GeneratorCore;
 internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 {
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
+    private const int DATA_TABLE_FLAGS_NONE = 0;
 
     private readonly GenerationContext m_Context;
     private readonly Func<ISheet, BinaryWriter, int> m_WriteDataRows;
@@ -50,12 +51,15 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 
             binaryWriter.Write(DATA_TABLE_SIGNATURE);
             binaryWriter.Write(DATA_TABLE_VERSION);
+            binaryWriter.Write(DataTableSchemaHash.Compute(m_Context));
+            binaryWriter.Write(GetGeneratorVersion());
+            binaryWriter.Write(m_Context.DataTableClassFullName);
+            long countPosition = fileStream.Position;
             binaryWriter.Write(ushort.MinValue);
+            binaryWriter.Write(DATA_TABLE_FLAGS_NONE);
 
             int dataRowCount = m_WriteDataRows(sheet, binaryWriter);
 
-            byte[] signatureBytes = Encoding.UTF8.GetBytes(DATA_TABLE_SIGNATURE);
-            long countPosition = DataTableProcessor.GetCompactIntSize(signatureBytes.Length) + signatureBytes.Length + sizeof(int);
             fileStream.Seek(countPosition, SeekOrigin.Begin);
             binaryWriter.Write((ushort)dataRowCount);
 
@@ -68,5 +72,10 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
             m_Context.Failed = true;
             if (File.Exists(outputFileName)) File.Delete(outputFileName);
         }
+    }
+
+    private static string GetGeneratorVersion()
+    {
+        return typeof(DataTableBinaryWriter).Assembly.GetName().Version?.ToString() ?? string.Empty;
     }
 }

--- a/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DataTables.GeneratorCore;
+
+internal static class DataTableSchemaHash
+{
+    public static ulong Compute(GenerationContext context)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var builder = new StringBuilder();
+        builder.Append("table=").Append(context.DataSetType).Append('\n');
+        builder.Append("fullName=").Append(context.DataTableClassFullName).Append('\n');
+
+        var ordinal = 0;
+        foreach (var field in context.Fields.Where(x => !x.IsIgnore).OrderBy(x => x.Index))
+        {
+            builder.Append(ordinal++)
+                .Append('|')
+                .Append(field.Name)
+                .Append('|')
+                .Append(field.TypeName)
+                .Append('\n');
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return BitConverter.ToUInt64(hash, 0);
+    }
+}

--- a/src/DataTables/DataTableBase.cs
+++ b/src/DataTables/DataTableBase.cs
@@ -27,6 +27,11 @@ namespace DataTables
         public string FullName => Type.ToString();
 
         /// <summary>
+        /// 获取生成代码期望的数据表结构哈希；旧生成代码返回 0。
+        /// </summary>
+        public virtual ulong SchemaHash => 0UL;
+
+        /// <summary>
         /// 获取数据表行的类型。
         /// </summary>
         public abstract Type Type

--- a/src/DataTables/DataTableManager.cs
+++ b/src/DataTables/DataTableManager.cs
@@ -120,7 +120,8 @@ namespace DataTables
     /// </summary>
     public static class DataTableManager
     {
-        private const int DataTableVersion = 2;
+        private const int DataTableVersion = 3;
+        private const int LegacyDataTableVersion = 2;
 
         #region InternalFields
 
@@ -607,15 +608,38 @@ namespace DataTables
             }
 
             var readVersion = br.ReadInt32();
-            if (readVersion != DataTableVersion)
+            if (readVersion > DataTableVersion)
             {
-                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'.");
+                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'. Current runtime supports up to {DataTableVersion}.");
             }
 
-            var readCount = br.ReadUInt16();
+            ulong schemaHash = 0UL;
+            string tableFullName = typeNamePair.Type.FullName ?? typeNamePair.Type.ToString();
+            int flags = 0;
+            ushort readCount;
+
+            if (readVersion <= LegacyDataTableVersion)
+            {
+                // Legacy format (v1/v2): Signature, FormatVersion, RowCount, followed by row payload.
+                readCount = br.ReadUInt16();
+            }
+            else
+            {
+                // Structured header (v3+): Signature, FormatVersion, SchemaHash, GeneratorVersion, TableFullName, RowCount, Flags.
+                schemaHash = br.ReadUInt64();
+                var generatorVersion = br.ReadString();
+                tableFullName = br.ReadString();
+                readCount = br.ReadUInt16();
+                flags = br.ReadInt32();
+            }
 
             // 尝试使用高性能工厂模式
             var dataTable = CreateDataTableInstance(typeNamePair, readCount);
+
+            if (readVersion > LegacyDataTableVersion)
+            {
+                ValidateStructuredHeader(typeNamePair, dataTable, schemaHash, tableFullName, flags);
+            }
 
             // 检查是否为矩阵表 (DataMatrixBase)
             if (IsMatrixTable(typeNamePair.Type))
@@ -646,6 +670,25 @@ namespace DataTables
             }
 
             return dataTable;
+        }
+
+        private static void ValidateStructuredHeader(TypeNamePair typeNamePair, DataTableBase dataTable, ulong schemaHash, string tableFullName, int flags)
+        {
+            if (flags != 0)
+            {
+                throw new Exception($"Unsupported data table flags 0x{flags:X8} for '{typeNamePair}'. This runtime cannot load compressed, encrypted, or extended payloads marked by these flags.");
+            }
+
+            var expectedFullName = typeNamePair.Type.FullName ?? typeNamePair.Type.ToString();
+            if (!string.Equals(tableFullName, expectedFullName, StringComparison.Ordinal))
+            {
+                throw new Exception($"Data table header mismatch for '{typeNamePair}': .bytes table '{tableFullName}' does not match generated code table '{expectedFullName}'. Regenerate code and data together.");
+            }
+
+            if (dataTable.SchemaHash != 0UL && dataTable.SchemaHash != schemaHash)
+            {
+                throw new Exception($"Data table schema mismatch for '{typeNamePair}': generated code schema hash 0x{dataTable.SchemaHash:X16} does not match .bytes data schema hash 0x{schemaHash:X16}. The generated code and .bytes data are out of sync; regenerate both from the same source table.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation

- Introduce a structured binary header so generated `.bytes` files carry explicit metadata instead of an ad-hoc layout.  
- Detect mismatches between generated C# table code and `.bytes` payloads early by embedding a schema hash at generation time and validating it at runtime.  
- Preserve backward compatibility for older `.bytes` (format versions 1/2) while providing a clear upgrade path and rejection policy for unsupported features.

### Description

- Bumped runtime format to `3` (`DataTableVersion = 3`) and added `LegacyDataTableVersion = 2` so `FormatVersion <= 2` uses the legacy read path.  
- Generation now writes a structured header: `Signature`, `FormatVersion`, `SchemaHash`, `GeneratorVersion`, `TableFullName`, `RowCount`, and `Flags`, and uses a placeholder for `RowCount` that is patched after writing payloads (`DataTableBinaryWriter`).  
- Added `DataTableSchemaHash` to compute a stable `ulong` from table type/fullname and non-ignored field ordinal/name/type, and emit the value into generated table classes via an override of `SchemaHash`.  
- Added a runtime validator `ValidateStructuredHeader` that rejects unknown non-zero `Flags`, mismatched `TableFullName`, and provides a clear error when the generated code `SchemaHash` differs from the `.bytes` `SchemaHash`.  
- Kept legacy reader behavior for older formats and documented the format upgrade, compatibility window, and `Flags` semantics in `README.md`.

### Testing

- Ran `git diff --check` which reported no whitespace or merge errors.  
- Attempted `dotnet --info` and `dotnet build DataTables.sln --no-restore` but the CI/container environment does not have the `dotnet` CLI installed, so a full build/test could not be executed here.  
- Verified repository changes were staged and committed locally (`Add structured binary table header`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b187b0dfc8331ae396dfe569da552)