### PR TITLE
Introduce structured .bytes header with schema hash and bump binary format to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,3 +733,23 @@ This library is under the MIT License.
 - 📢 向其他开发者推荐
 
 **感谢使用 DataTables！享受现代化高性能的开发体验！** 🚀
+
+## Binary format upgrade and compatibility
+
+Starting with binary format version 3, generated `.bytes` files use a structured header before the row payload:
+
+1. `Signature` (`DTABLE`)
+2. `FormatVersion`
+3. `SchemaHash`
+4. `GeneratorVersion`
+5. `TableFullName`
+6. `RowCount`
+7. `Flags`
+
+The schema hash is calculated during generation from the effective exported schema: table type, table full name, and each non-ignored field's name, type, and order. Runtime loading validates the `.bytes` schema hash against the hash embedded in the generated table class, so a mismatch clearly indicates that the generated C# code and binary data were not produced from the same table schema.
+
+Upgrade policy:
+
+* Format version `3` is a breaking binary format used by the next major release; older format versions are not read by this runtime.
+* Runtimes require the exact binary format version they were built for. When upgrading, regenerate both the C# table code and `.bytes` assets together and publish them with the matching major runtime.
+* `Flags` is reserved for payload features such as compression, encryption, or an embedded default-value table. Unknown non-zero flags are rejected by the runtime until explicit support is added.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [🏆 性能基准](#-%E6%80%A7%E8%83%BD%E5%9F%BA%E5%87%86)
   - [📜 License](#-license)
   - [🌟 支持项目](#-%E6%94%AF%E6%8C%81%E9%A1%B9%E7%9B%AE)
+  - [Binary format upgrade and compatibility](#binary-format-upgrade-and-compatibility)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
@@ -59,7 +59,9 @@ namespace DataTables.GeneratorCore
             
             #line default
             #line hidden
-            this.Write(">\r\n{\r\n    ");
+            this.Write(">\r\n{\r\n    public override ulong SchemaHash => ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(DataTableSchemaHash.Compute(GenerationContext)));
+            this.Write("UL;\r\n\r\n    ");
             
             this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(GenerationContext.MatrixDefaultValue) ? string.Empty : "protected override " + BuildTypeString(kValue) + " DefaultValue => " + BuildTypeValueString(kValue, GenerationContext.MatrixDefaultValue) + ";" + Environment.NewLine));
             

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -13,7 +13,7 @@ public sealed partial class DataTableProcessor : IDisposable
 {
     private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
 
     private readonly GenerationContext m_Context;
     private readonly IFormulaEvaluator m_FormulaEvaluator;

--- a/src/DataTables.GeneratorCore/DataTableTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataTableTemplate.cs
@@ -31,6 +31,8 @@ public partial class DataTableTemplate
         if (!string.IsNullOrEmpty(Namespace)) { WL($"namespace {Namespace}"); WL("{"); }
         WL($"public sealed partial class {GenerationContext.DataTableClassName} : DataTable<{GenerationContext.DataRowClassName}>");
         WL("{");
+        WL($"    public override ulong SchemaHash => {DataTableSchemaHash.Compute(GenerationContext)}UL;");
+        WL();
         var dictIndex = 1;
         foreach (var index in GenerationContext.IndexDefinitions)
         {

--- a/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
@@ -9,7 +9,8 @@ namespace DataTables.GeneratorCore;
 internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 {
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
+    private const int DATA_TABLE_FLAGS_NONE = 0;
 
     private readonly GenerationContext m_Context;
     private readonly Func<ISheet, BinaryWriter, int> m_WriteDataRows;
@@ -50,12 +51,15 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 
             binaryWriter.Write(DATA_TABLE_SIGNATURE);
             binaryWriter.Write(DATA_TABLE_VERSION);
+            binaryWriter.Write(DataTableSchemaHash.Compute(m_Context));
+            binaryWriter.Write(GetGeneratorVersion());
+            binaryWriter.Write(m_Context.DataTableClassFullName);
+            long countPosition = fileStream.Position;
             binaryWriter.Write(ushort.MinValue);
+            binaryWriter.Write(DATA_TABLE_FLAGS_NONE);
 
             int dataRowCount = m_WriteDataRows(sheet, binaryWriter);
 
-            byte[] signatureBytes = Encoding.UTF8.GetBytes(DATA_TABLE_SIGNATURE);
-            long countPosition = DataTableProcessor.GetCompactIntSize(signatureBytes.Length) + signatureBytes.Length + sizeof(int);
             fileStream.Seek(countPosition, SeekOrigin.Begin);
             binaryWriter.Write((ushort)dataRowCount);
 
@@ -68,5 +72,10 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
             m_Context.Failed = true;
             if (File.Exists(outputFileName)) File.Delete(outputFileName);
         }
+    }
+
+    private static string GetGeneratorVersion()
+    {
+        return typeof(DataTableBinaryWriter).Assembly.GetName().Version?.ToString() ?? string.Empty;
     }
 }

--- a/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DataTables.GeneratorCore;
+
+internal static class DataTableSchemaHash
+{
+    public static ulong Compute(GenerationContext context)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var builder = new StringBuilder();
+        builder.Append("table=").Append(context.DataSetType).Append('\n');
+        builder.Append("fullName=").Append(context.DataTableClassFullName).Append('\n');
+
+        var ordinal = 0;
+        foreach (var field in context.Fields.Where(x => !x.IsIgnore).OrderBy(x => x.Index))
+        {
+            builder.Append(ordinal++)
+                .Append('|')
+                .Append(field.Name)
+                .Append('|')
+                .Append(field.TypeName)
+                .Append('\n');
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return BitConverter.ToUInt64(hash, 0);
+    }
+}

--- a/src/DataTables/DataTableBase.cs
+++ b/src/DataTables/DataTableBase.cs
@@ -27,6 +27,11 @@ namespace DataTables
         public string FullName => Type.ToString();
 
         /// <summary>
+        /// 获取生成代码期望的数据表结构哈希。
+        /// </summary>
+        public virtual ulong SchemaHash => 0UL;
+
+        /// <summary>
         /// 获取数据表行的类型。
         /// </summary>
         public abstract Type Type

--- a/src/DataTables/DataTableManager.cs
+++ b/src/DataTables/DataTableManager.cs
@@ -120,7 +120,7 @@ namespace DataTables
     /// </summary>
     public static class DataTableManager
     {
-        private const int DataTableVersion = 2;
+        private const int DataTableVersion = 3;
 
         #region InternalFields
 
@@ -609,13 +609,19 @@ namespace DataTables
             var readVersion = br.ReadInt32();
             if (readVersion != DataTableVersion)
             {
-                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'.");
+                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'. This major runtime requires binary format version {DataTableVersion}; regenerate the .bytes data and generated code together.");
             }
 
+            // Structured header: Signature, FormatVersion, SchemaHash, GeneratorVersion, TableFullName, RowCount, Flags.
+            var schemaHash = br.ReadUInt64();
+            _ = br.ReadString(); // GeneratorVersion is informational for diagnostics/versioned assets.
+            var tableFullName = br.ReadString();
             var readCount = br.ReadUInt16();
+            var flags = br.ReadInt32();
 
             // 尝试使用高性能工厂模式
             var dataTable = CreateDataTableInstance(typeNamePair, readCount);
+            ValidateStructuredHeader(typeNamePair, dataTable, schemaHash, tableFullName, flags);
 
             // 检查是否为矩阵表 (DataMatrixBase)
             if (IsMatrixTable(typeNamePair.Type))
@@ -646,6 +652,25 @@ namespace DataTables
             }
 
             return dataTable;
+        }
+
+        private static void ValidateStructuredHeader(TypeNamePair typeNamePair, DataTableBase dataTable, ulong schemaHash, string tableFullName, int flags)
+        {
+            if (flags != 0)
+            {
+                throw new Exception($"Unsupported data table flags 0x{flags:X8} for '{typeNamePair}'. This runtime cannot load compressed, encrypted, or extended payloads marked by these flags.");
+            }
+
+            var expectedFullName = typeNamePair.Type.FullName ?? typeNamePair.Type.ToString();
+            if (!string.Equals(tableFullName, expectedFullName, StringComparison.Ordinal))
+            {
+                throw new Exception($"Data table header mismatch for '{typeNamePair}': .bytes table '{tableFullName}' does not match generated code table '{expectedFullName}'. Regenerate code and data together.");
+            }
+
+            if (dataTable.SchemaHash != schemaHash)
+            {
+                throw new Exception($"Data table schema mismatch for '{typeNamePair}': generated code schema hash 0x{dataTable.SchemaHash:X16} does not match .bytes data schema hash 0x{schemaHash:X16}. The generated code and .bytes data are out of sync; regenerate both from the same source table.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation

- Introduce an explicit structured binary header to ensure generated C# table code and binary `.bytes` assets are tightly coupled and detect mismatches at load time.
- Bump the on-disk binary format to a new major version to enable forward-looking features (generator version, flags, etc.) while preventing accidental loading of incompatible assets.

### Description

- Bump binary format version from `2` to `3` by updating `DataTableProcessor`, `DataTableBinaryWriter`, and `DataTableManager` to use `DATA_TABLE_VERSION = 3` and related handling.
- Add a structured header to generated `.bytes` files containing `Signature`, `FormatVersion`, `SchemaHash`, `GeneratorVersion`, `TableFullName`, `RowCount`, and `Flags` in the writer (`DataTableBinaryWriter`) and make the writer emit `GeneratorVersion` via `GetGeneratorVersion()` and `Flags` (currently `DATA_TABLE_FLAGS_NONE`).
- Add `DataTableSchemaHash` utility to compute a stable schema hash from the effective exported schema and wire it into generated code via `SchemaHash` overrides in `DataTableTemplate` and `DataMatrixTemplate`, and expose a virtual `SchemaHash` on `DataTableBase`.
- Add runtime validation in `DataTableManager.LoadDataTableFromBytes` with `ValidateStructuredHeader` to reject unknown non-zero `Flags`, mismatched `TableFullName`, and schema-hash differences with clear error messages directing to regenerate code and data together.
- Update `README.md` with the binary format upgrade notes, compatibility/upgrade policy, and header field documentation.

### Testing

- Ran the generator unit and integration tests that exercise `.bytes` generation and runtime loading (writer -> reader round-trip) and verified successful generation and loading for matching schema and code; all automated tests passed.
- Exercised negative cases for schema mismatch and unknown `Flags` to confirm the runtime rejects incompatible assets with the new diagnostic messages; checks succeeded in automated validation tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b187b0dfc8331ae396dfe569da552)