### PR TITLE
Introduce structured binary header (format v3) with schema hash and runtime validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,3 +733,23 @@ This library is under the MIT License.
 - 📢 向其他开发者推荐
 
 **感谢使用 DataTables！享受现代化高性能的开发体验！** 🚀
+
+## Binary format upgrade and compatibility
+
+Starting with binary format version 3, generated `.bytes` files use a structured header before the row payload:
+
+1. `Signature` (`DTABLE`)
+2. `FormatVersion`
+3. `SchemaHash`
+4. `GeneratorVersion`
+5. `TableFullName`
+6. `RowCount`
+7. `Flags`
+
+The schema hash is calculated during generation from the effective exported schema: table type, table full name, and each non-ignored field's name, type, and order. Runtime loading validates the `.bytes` schema hash against the hash embedded in the generated table class, so a mismatch clearly indicates that the generated C# code and binary data were not produced from the same table schema.
+
+Upgrade policy:
+
+* Format version `3` is a breaking binary format used by the next major release; older format versions are not read by this runtime.
+* Runtimes require the exact binary format version they were built for. When upgrading, regenerate both the C# table code and `.bytes` assets together and publish them with the matching major runtime.
+* `Flags` is reserved for payload features such as compression, encryption, or an embedded default-value table. Unknown non-zero flags are rejected by the runtime until explicit support is added.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [🏆 性能基准](#-%E6%80%A7%E8%83%BD%E5%9F%BA%E5%87%86)
   - [📜 License](#-license)
   - [🌟 支持项目](#-%E6%94%AF%E6%8C%81%E9%A1%B9%E7%9B%AE)
+  - [Binary format upgrade and compatibility](#binary-format-upgrade-and-compatibility)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataMatrixTemplate.cs
@@ -59,7 +59,9 @@ namespace DataTables.GeneratorCore
             
             #line default
             #line hidden
-            this.Write(">\r\n{\r\n    ");
+            this.Write(">\r\n{\r\n    public override ulong SchemaHash => ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(DataTableSchemaHash.Compute(GenerationContext)));
+            this.Write("UL;\r\n\r\n    ");
             
             this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(GenerationContext.MatrixDefaultValue) ? string.Empty : "protected override " + BuildTypeString(kValue) + " DefaultValue => " + BuildTypeValueString(kValue, GenerationContext.MatrixDefaultValue) + ";" + Environment.NewLine));
             

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -13,7 +13,7 @@ public sealed partial class DataTableProcessor : IDisposable
 {
     private static readonly Regex NameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9_]*$");
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
 
     private readonly GenerationContext m_Context;
     private readonly IFormulaEvaluator m_FormulaEvaluator;

--- a/src/DataTables.GeneratorCore/DataTableTemplate.cs
+++ b/src/DataTables.GeneratorCore/DataTableTemplate.cs
@@ -31,6 +31,8 @@ public partial class DataTableTemplate
         if (!string.IsNullOrEmpty(Namespace)) { WL($"namespace {Namespace}"); WL("{"); }
         WL($"public sealed partial class {GenerationContext.DataTableClassName} : DataTable<{GenerationContext.DataRowClassName}>");
         WL("{");
+        WL($"    public override ulong SchemaHash => {DataTableSchemaHash.Compute(GenerationContext)}UL;");
+        WL();
         var dictIndex = 1;
         foreach (var index in GenerationContext.IndexDefinitions)
         {

--- a/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableBinaryWriter.cs
@@ -9,7 +9,8 @@ namespace DataTables.GeneratorCore;
 internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 {
     private const string DATA_TABLE_SIGNATURE = "DTABLE";
-    private const int DATA_TABLE_VERSION = 2;
+    private const int DATA_TABLE_VERSION = 3;
+    private const int DATA_TABLE_FLAGS_NONE = 0;
 
     private readonly GenerationContext m_Context;
     private readonly Func<ISheet, BinaryWriter, int> m_WriteDataRows;
@@ -50,12 +51,15 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
 
             binaryWriter.Write(DATA_TABLE_SIGNATURE);
             binaryWriter.Write(DATA_TABLE_VERSION);
+            binaryWriter.Write(DataTableSchemaHash.Compute(m_Context));
+            binaryWriter.Write(GetGeneratorVersion());
+            binaryWriter.Write(m_Context.DataTableClassFullName);
+            long countPosition = fileStream.Position;
             binaryWriter.Write(ushort.MinValue);
+            binaryWriter.Write(DATA_TABLE_FLAGS_NONE);
 
             int dataRowCount = m_WriteDataRows(sheet, binaryWriter);
 
-            byte[] signatureBytes = Encoding.UTF8.GetBytes(DATA_TABLE_SIGNATURE);
-            long countPosition = DataTableProcessor.GetCompactIntSize(signatureBytes.Length) + signatureBytes.Length + sizeof(int);
             fileStream.Seek(countPosition, SeekOrigin.Begin);
             binaryWriter.Write((ushort)dataRowCount);
 
@@ -68,5 +72,10 @@ internal sealed class DataTableBinaryWriter : IDataTableBinaryWriter
             m_Context.Failed = true;
             if (File.Exists(outputFileName)) File.Delete(outputFileName);
         }
+    }
+
+    private static string GetGeneratorVersion()
+    {
+        return typeof(DataTableBinaryWriter).Assembly.GetName().Version?.ToString() ?? string.Empty;
     }
 }

--- a/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
+++ b/src/DataTables.GeneratorCore/Serialization/DataTableSchemaHash.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DataTables.GeneratorCore;
+
+internal static class DataTableSchemaHash
+{
+    public static ulong Compute(GenerationContext context)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var builder = new StringBuilder();
+        builder.Append("table=").Append(context.DataSetType).Append('\n');
+        builder.Append("fullName=").Append(context.DataTableClassFullName).Append('\n');
+
+        var ordinal = 0;
+        foreach (var field in context.Fields.Where(x => !x.IsIgnore).OrderBy(x => x.Index))
+        {
+            builder.Append(ordinal++)
+                .Append('|')
+                .Append(field.Name)
+                .Append('|')
+                .Append(field.TypeName)
+                .Append('\n');
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return BitConverter.ToUInt64(hash, 0);
+    }
+}

--- a/src/DataTables/DataTableBase.cs
+++ b/src/DataTables/DataTableBase.cs
@@ -27,6 +27,11 @@ namespace DataTables
         public string FullName => Type.ToString();
 
         /// <summary>
+        /// 获取生成代码期望的数据表结构哈希。
+        /// </summary>
+        public virtual ulong SchemaHash => 0UL;
+
+        /// <summary>
         /// 获取数据表行的类型。
         /// </summary>
         public abstract Type Type

--- a/src/DataTables/DataTableManager.cs
+++ b/src/DataTables/DataTableManager.cs
@@ -120,7 +120,7 @@ namespace DataTables
     /// </summary>
     public static class DataTableManager
     {
-        private const int DataTableVersion = 2;
+        private const int DataTableVersion = 3;
 
         #region InternalFields
 
@@ -609,13 +609,19 @@ namespace DataTables
             var readVersion = br.ReadInt32();
             if (readVersion != DataTableVersion)
             {
-                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'.");
+                throw new Exception($"Unsupported data table version {readVersion} for '{typeNamePair}'. This major runtime requires binary format version {DataTableVersion}; regenerate the .bytes data and generated code together.");
             }
 
+            // Structured header: Signature, FormatVersion, SchemaHash, GeneratorVersion, TableFullName, RowCount, Flags.
+            var schemaHash = br.ReadUInt64();
+            _ = br.ReadString(); // GeneratorVersion is informational for diagnostics/versioned assets.
+            var tableFullName = br.ReadString();
             var readCount = br.ReadUInt16();
+            var flags = br.ReadInt32();
 
             // 尝试使用高性能工厂模式
             var dataTable = CreateDataTableInstance(typeNamePair, readCount);
+            ValidateStructuredHeader(typeNamePair, dataTable, schemaHash, tableFullName, flags);
 
             // 检查是否为矩阵表 (DataMatrixBase)
             if (IsMatrixTable(typeNamePair.Type))
@@ -646,6 +652,25 @@ namespace DataTables
             }
 
             return dataTable;
+        }
+
+        private static void ValidateStructuredHeader(TypeNamePair typeNamePair, DataTableBase dataTable, ulong schemaHash, string tableFullName, int flags)
+        {
+            if (flags != 0)
+            {
+                throw new Exception($"Unsupported data table flags 0x{flags:X8} for '{typeNamePair}'. This runtime cannot load compressed, encrypted, or extended payloads marked by these flags.");
+            }
+
+            var expectedFullName = typeNamePair.Type.FullName ?? typeNamePair.Type.ToString();
+            if (!string.Equals(tableFullName, expectedFullName, StringComparison.Ordinal))
+            {
+                throw new Exception($"Data table header mismatch for '{typeNamePair}': .bytes table '{tableFullName}' does not match generated code table '{expectedFullName}'. Regenerate code and data together.");
+            }
+
+            if (dataTable.SchemaHash != schemaHash)
+            {
+                throw new Exception($"Data table schema mismatch for '{typeNamePair}': generated code schema hash 0x{dataTable.SchemaHash:X16} does not match .bytes data schema hash 0x{schemaHash:X16}. The generated code and .bytes data are out of sync; regenerate both from the same source table.");
+            }
         }
 
         /// <summary>

--- a/tests/DataTables.Tests/ColumnTableTest.cs
+++ b/tests/DataTables.Tests/ColumnTableTest.cs
@@ -89,8 +89,17 @@ namespace DataTables.Tests
             // 读取版本
             int version = br.ReadInt32();
             version.Should().BeGreaterThan(0);
-            // 读取行数 7-bit 编码
+            // 读取结构化 header
+            ulong schemaHash = br.ReadUInt64();
+            string generatorVersion = br.ReadString();
+            string tableFullName = br.ReadString();
             int rowCount = br.ReadUInt16();
+            int flags = br.ReadInt32();
+
+            schemaHash.Should().NotBe(0UL);
+            generatorVersion.Should().NotBeNull();
+            tableFullName.Should().Be("DataTables.Tests.Generated.DTItemConfig");
+            flags.Should().Be(0);
             // 示例中：三条数据（1001/1002/1003）
             rowCount.Should().Be(3);
         }

--- a/tests/DataTables.Tests/ConcurrencyTest.cs
+++ b/tests/DataTables.Tests/ConcurrencyTest.cs
@@ -118,8 +118,12 @@ namespace DataTables.Tests
             using var bw = new System.IO.BinaryWriter(ms);
 
             bw.Write("DTABLE");  // 签名
-            bw.Write(2);         // 版本
+            bw.Write(3);         // 版本
+            bw.Write(1UL);       // SchemaHash
+            bw.Write("test");   // GeneratorVersion
+            bw.Write(tableName); // TableFullName
             bw.Write(ushort.MinValue); // 数据行数
+            bw.Write(0);         // Flags
 
             return ms.ToArray();
         }
@@ -127,16 +131,22 @@ namespace DataTables.Tests
 
     public class MockDataTable : DataTable<MockDataRow>
     {
+        public override ulong SchemaHash => 1UL;
+
         public MockDataTable(string name, int capacity) : base(name, capacity) { }
     }
 
     public class MockDataTable2 : DataTable<MockDataRow>
     {
+        public override ulong SchemaHash => 1UL;
+
         public MockDataTable2(string name, int capacity) : base(name, capacity) { }
     }
 
     public class MockDataTable3 : DataTable<MockDataRow>
     {
+        public override ulong SchemaHash => 1UL;
+
         public MockDataTable3(string name, int capacity) : base(name, capacity) { }
     }
 

--- a/tests/DataTables.Tests/PerformanceBenchmarkTest.cs
+++ b/tests/DataTables.Tests/PerformanceBenchmarkTest.cs
@@ -152,8 +152,12 @@ namespace DataTables.Tests
             using var bw = new System.IO.BinaryWriter(ms);
 
             bw.Write("DTABLE");  // 签名
-            bw.Write(2);         // 版本
+            bw.Write(3);         // 版本
+            bw.Write(1UL);       // SchemaHash
+            bw.Write("test");   // GeneratorVersion
+            bw.Write(tableName); // TableFullName
             bw.Write(ushort.MinValue); // 数据行数
+            bw.Write(0);         // Flags
 
             return ms.ToArray();
         }


### PR DESCRIPTION
### Motivation

- Ensure generated C# table classes and `.bytes` assets are provably in sync by embedding a schema hash in the binary payload.
- Move to a structured binary header to allow embedding metadata (generator version, table name, flags) and to enable future features like compression or encryption without silent failures.
- Make mismatches fail fast with clear diagnostics to avoid subtle runtime deserialization errors.

### Description

- Bump binary format to `3` across writer and runtime and emit/consume a structured header containing `Signature`, `FormatVersion`, `SchemaHash`, `GeneratorVersion`, `TableFullName`, `RowCount`, and `Flags`.
- Add `DataTableSchemaHash` to compute a stable schema hash from the generation context using SHA256 and expose it as a `ulong` in generated table classes via an override of the new `SchemaHash` virtual property on `DataTableBase`.
- Update generator templates to emit `SchemaHash` into generated table classes and update the binary writer to write the generator version and `Flags` (currently `0`), and add a helper `GetGeneratorVersion()`.
- Update runtime loading to validate the structured header: enforce format version equality, check `Flags` (reject unknown non-zero flags), verify `TableFullName` matches the generated type, and compare the embedded schema hash to the generated class `SchemaHash`, failing with informative messages when mismatched.
- Update `README.md` with the format v3 header layout and upgrade policy, and adjust generator/runtime tests to assert new header fields.

### Testing

- Updated and ran unit tests that read/generate `.bytes` files including `ColumnTableTest`, `ConcurrencyTest`, and `PerformanceBenchmarkTest`, and the tests assert the presence and values of `SchemaHash`, `GeneratorVersion`, `TableFullName`, `RowCount`, and `Flags`.
- Executed the test suite (`dotnet test`) after modifications and the updated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b187b0dfc8331ae396dfe569da552)