### PR TITLE
Add data source manifest diagnostics, fallback hit tracking and versioned manifest mapping

### DIFF
--- a/docs/data-source-pipeline.md
+++ b/docs/data-source-pipeline.md
@@ -1,0 +1,32 @@
+# 数据源管线
+
+DataTables 运行时采用**传输层处理优先**的模型：`IDataSource` 及其装饰器负责网络、缓存、回退、解压和解密，进入 `DataTableManager` 的字节流应当已经是明文 DataTables payload。二进制 header 中的 flags 当前作为扩展位保留，运行时仍会拒绝非零 payload flags。
+
+## Manifest 条目约定
+
+`DataSourceManifestEntry` 用于描述可加载资源的稳定元数据：
+
+| 字段 | 说明 |
+| --- | --- |
+| `Name` | 逻辑表名或资源名，不包含 `.bytes` 扩展名。 |
+| `Length` | 资源字节长度；未知时可为空。 |
+| `Version` | 单个资源版本；为空时可继承 manifest 级 `Version`。 |
+| `Hash` | 资源内容 hash，推荐使用小写 hex SHA-256。 |
+| `SourceName` | 提供该条目的数据源诊断名，主要由 fallback 合并 manifest 时填充。 |
+
+## VersionedDataSource
+
+`VersionedDataSource` 默认把逻辑名 `Hero` 映射到 `{version}/Hero` 加载，例如版本 `v2` 会加载 `v2/Hero.bytes`。读取 manifest 时会反向过滤当前版本前缀，只把 `v2/Hero`、`v2/Item` 暴露为逻辑名 `Hero`、`Item`，并把缺失的条目版本补为当前版本。
+
+如果项目使用自定义路径规则，可以传入自定义 `nameResolver` 和 `manifestEntryMapper`，确保加载路径和 manifest 逻辑名保持一致。
+
+## FallbackDataSource 诊断
+
+`FallbackDataSource` 按顺序尝试每个数据源：
+
+1. `ExistsAsync` 返回 `false` 时记录 `not found`。
+2. 加载异常时记录对应数据源和错误消息。
+3. 成功加载时更新 `LastHitSource`，方便日志和性能面板展示最终命中来源。
+4. 合并 manifest 时保留第一个出现的逻辑名，并把来源写入 `SourceName`。
+
+当所有数据源都失败时，抛出的 `FileNotFoundException` 会包含每个数据源的尝试结果，便于区分“本地缓存缺失”“远端不可用”和“资源损坏”。

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
@@ -110,6 +110,8 @@ namespace DataTables
     {
         private readonly IReadOnlyList<IDataSource> _sources;
 
+        public string? LastHitSource { get; private set; }
+
         public FallbackDataSource(params IDataSource[] sources) : this((IEnumerable<IDataSource>)sources)
         {
         }
@@ -130,25 +132,31 @@ namespace DataTables
         public async ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken)
         {
             Exception? lastError = null;
+            var failures = new List<string>();
             foreach (var source in _sources)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
+                    var sourceName = GetSourceName(source);
                     if (!await source.ExistsAsync(name, cancellationToken))
                     {
+                        failures.Add($"{sourceName}: not found");
                         continue;
                     }
 
-                    return await source.LoadAsync(name, cancellationToken);
+                    var bytes = await source.LoadAsync(name, cancellationToken);
+                    LastHitSource = sourceName;
+                    return bytes;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     lastError = ex;
+                    failures.Add($"{GetSourceName(source)}: {ex.Message}");
                 }
             }
 
-            throw new FileNotFoundException($"所有数据源都无法加载: {name}", lastError);
+            throw new FileNotFoundException($"所有数据源都无法加载: {name}. 尝试结果: {string.Join("; ", failures)}", lastError);
         }
 
         public async ValueTask<bool> ExistsAsync(string name, CancellationToken cancellationToken)
@@ -172,11 +180,22 @@ namespace DataTables
                 var manifest = await source.GetManifestAsync(cancellationToken);
                 foreach (var entry in manifest.Entries)
                 {
-                    entries.TryAdd(entry.Name, entry);
+                    entries.TryAdd(entry.Name, new DataSourceManifestEntry(entry.Name, entry.Length, entry.Version ?? manifest.Version, entry.Hash, GetSourceName(source)));
                 }
             }
 
             return new DataSourceManifest(entries.Values.ToArray());
+        }
+
+        private static string GetSourceName(IDataSource source)
+        {
+            var displayName = source.ToString();
+            if (string.IsNullOrWhiteSpace(displayName) || displayName == source.GetType().FullName)
+            {
+                displayName = source.GetType().Name;
+            }
+
+            return $"{source.SourceType}:{displayName}";
         }
 
         public async ValueTask<bool> IsAvailableAsync()
@@ -197,11 +216,13 @@ namespace DataTables
     {
         private readonly string _version;
         private readonly Func<string, string, string> _nameResolver;
+        private readonly Func<DataSourceManifestEntry, string, DataSourceManifestEntry?> _manifestEntryMapper;
 
-        public VersionedDataSource(IDataSource inner, string version, Func<string, string, string>? nameResolver = null) : base(inner)
+        public VersionedDataSource(IDataSource inner, string version, Func<string, string, string>? nameResolver = null, Func<DataSourceManifestEntry, string, DataSourceManifestEntry?>? manifestEntryMapper = null) : base(inner)
         {
             _version = version ?? throw new ArgumentNullException(nameof(version));
             _nameResolver = nameResolver ?? ((name, version) => $"{version}/{name}");
+            _manifestEntryMapper = manifestEntryMapper ?? MapDefaultVersionedEntry;
         }
 
         public override ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken) => Inner.LoadAsync(_nameResolver(name, _version), cancellationToken);
@@ -211,7 +232,28 @@ namespace DataTables
         public override async ValueTask<DataSourceManifest> GetManifestAsync(CancellationToken cancellationToken)
         {
             var manifest = await Inner.GetManifestAsync(cancellationToken);
-            return new DataSourceManifest(manifest.Entries, _version);
+            var entries = manifest.Entries
+                .Select(entry => _manifestEntryMapper(entry, _version))
+                .Where(entry => entry != null)
+                .Select(entry => entry!)
+                .ToArray();
+            return new DataSourceManifest(entries, _version);
+        }
+
+        private static DataSourceManifestEntry? MapDefaultVersionedEntry(DataSourceManifestEntry entry, string version)
+        {
+            var prefix = version.TrimEnd('/') + "/";
+            if (!entry.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return new DataSourceManifestEntry(
+                entry.Name.Substring(prefix.Length),
+                entry.Length,
+                entry.Version ?? version,
+                entry.Hash,
+                entry.SourceName);
         }
     }
 }

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
@@ -78,12 +78,13 @@ namespace DataTables
     /// </summary>
     public sealed class DataSourceManifestEntry
     {
-        public DataSourceManifestEntry(string name, long? length = null, string? version = null, string? hash = null)
+        public DataSourceManifestEntry(string name, long? length = null, string? version = null, string? hash = null, string? sourceName = null)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Length = length;
             Version = version;
             Hash = hash;
+            SourceName = sourceName;
         }
 
         public string Name { get; }
@@ -93,6 +94,11 @@ namespace DataTables
         public string? Version { get; }
 
         public string? Hash { get; }
+
+        /// <summary>
+        /// 提供该条目的数据源名称，用于 fallback/manifest 诊断。
+        /// </summary>
+        public string? SourceName { get; }
     }
 
     /// <summary>

--- a/src/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables/DataSourceDecorators.cs
@@ -110,6 +110,8 @@ namespace DataTables
     {
         private readonly IReadOnlyList<IDataSource> _sources;
 
+        public string? LastHitSource { get; private set; }
+
         public FallbackDataSource(params IDataSource[] sources) : this((IEnumerable<IDataSource>)sources)
         {
         }
@@ -130,25 +132,31 @@ namespace DataTables
         public async ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken)
         {
             Exception? lastError = null;
+            var failures = new List<string>();
             foreach (var source in _sources)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
+                    var sourceName = GetSourceName(source);
                     if (!await source.ExistsAsync(name, cancellationToken))
                     {
+                        failures.Add($"{sourceName}: not found");
                         continue;
                     }
 
-                    return await source.LoadAsync(name, cancellationToken);
+                    var bytes = await source.LoadAsync(name, cancellationToken);
+                    LastHitSource = sourceName;
+                    return bytes;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     lastError = ex;
+                    failures.Add($"{GetSourceName(source)}: {ex.Message}");
                 }
             }
 
-            throw new FileNotFoundException($"所有数据源都无法加载: {name}", lastError);
+            throw new FileNotFoundException($"所有数据源都无法加载: {name}. 尝试结果: {string.Join("; ", failures)}", lastError);
         }
 
         public async ValueTask<bool> ExistsAsync(string name, CancellationToken cancellationToken)
@@ -172,11 +180,22 @@ namespace DataTables
                 var manifest = await source.GetManifestAsync(cancellationToken);
                 foreach (var entry in manifest.Entries)
                 {
-                    entries.TryAdd(entry.Name, entry);
+                    entries.TryAdd(entry.Name, new DataSourceManifestEntry(entry.Name, entry.Length, entry.Version ?? manifest.Version, entry.Hash, GetSourceName(source)));
                 }
             }
 
             return new DataSourceManifest(entries.Values.ToArray());
+        }
+
+        private static string GetSourceName(IDataSource source)
+        {
+            var displayName = source.ToString();
+            if (string.IsNullOrWhiteSpace(displayName) || displayName == source.GetType().FullName)
+            {
+                displayName = source.GetType().Name;
+            }
+
+            return $"{source.SourceType}:{displayName}";
         }
 
         public async ValueTask<bool> IsAvailableAsync()
@@ -197,11 +216,13 @@ namespace DataTables
     {
         private readonly string _version;
         private readonly Func<string, string, string> _nameResolver;
+        private readonly Func<DataSourceManifestEntry, string, DataSourceManifestEntry?> _manifestEntryMapper;
 
-        public VersionedDataSource(IDataSource inner, string version, Func<string, string, string>? nameResolver = null) : base(inner)
+        public VersionedDataSource(IDataSource inner, string version, Func<string, string, string>? nameResolver = null, Func<DataSourceManifestEntry, string, DataSourceManifestEntry?>? manifestEntryMapper = null) : base(inner)
         {
             _version = version ?? throw new ArgumentNullException(nameof(version));
             _nameResolver = nameResolver ?? ((name, version) => $"{version}/{name}");
+            _manifestEntryMapper = manifestEntryMapper ?? MapDefaultVersionedEntry;
         }
 
         public override ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken) => Inner.LoadAsync(_nameResolver(name, _version), cancellationToken);
@@ -211,7 +232,28 @@ namespace DataTables
         public override async ValueTask<DataSourceManifest> GetManifestAsync(CancellationToken cancellationToken)
         {
             var manifest = await Inner.GetManifestAsync(cancellationToken);
-            return new DataSourceManifest(manifest.Entries, _version);
+            var entries = manifest.Entries
+                .Select(entry => _manifestEntryMapper(entry, _version))
+                .Where(entry => entry != null)
+                .Select(entry => entry!)
+                .ToArray();
+            return new DataSourceManifest(entries, _version);
+        }
+
+        private static DataSourceManifestEntry? MapDefaultVersionedEntry(DataSourceManifestEntry entry, string version)
+        {
+            var prefix = version.TrimEnd('/') + "/";
+            if (!entry.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return new DataSourceManifestEntry(
+                entry.Name.Substring(prefix.Length),
+                entry.Length,
+                entry.Version ?? version,
+                entry.Hash,
+                entry.SourceName);
         }
     }
 }

--- a/src/DataTables/IDataSource.cs
+++ b/src/DataTables/IDataSource.cs
@@ -78,12 +78,13 @@ namespace DataTables
     /// </summary>
     public sealed class DataSourceManifestEntry
     {
-        public DataSourceManifestEntry(string name, long? length = null, string? version = null, string? hash = null)
+        public DataSourceManifestEntry(string name, long? length = null, string? version = null, string? hash = null, string? sourceName = null)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Length = length;
             Version = version;
             Hash = hash;
+            SourceName = sourceName;
         }
 
         public string Name { get; }
@@ -93,6 +94,11 @@ namespace DataTables
         public string? Version { get; }
 
         public string? Hash { get; }
+
+        /// <summary>
+        /// 提供该条目的数据源名称，用于 fallback/manifest 诊断。
+        /// </summary>
+        public string? SourceName { get; }
     }
 
     /// <summary>

--- a/tests/DataTables.Tests/DataSourcePipelineTests.cs
+++ b/tests/DataTables.Tests/DataSourcePipelineTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DataTables;
+using FluentAssertions;
+using Xunit;
+
+namespace DataTables.Tests;
+
+public class DataSourcePipelineTests
+{
+    [Fact]
+    public async Task FallbackDataSource_Should_Record_Hit_Source_And_Manifest_Source()
+    {
+        var first = new StubDataSource("primary", false, new DataSourceManifestEntry("Config", 10, "old", "hash-old"));
+        var second = new StubDataSource("backup", true, new DataSourceManifestEntry("Config", 12, "new", "hash-new"));
+        var fallback = new FallbackDataSource(first, second);
+
+        var bytes = await fallback.LoadAsync("Config", CancellationToken.None);
+        var manifest = await fallback.GetManifestAsync(CancellationToken.None);
+
+        bytes.Should().Equal(1, 2, 3);
+        fallback.LastHitSource.Should().Be("Memory:backup");
+        manifest.Entries.Single().SourceName.Should().Be("Memory:primary");
+        manifest.Entries.Single().Version.Should().Be("old", "first source wins for fallback manifest entries");
+    }
+
+    [Fact]
+    public async Task FallbackDataSource_Should_Report_Attempted_Sources_When_All_Fail()
+    {
+        var fallback = new FallbackDataSource(
+            new StubDataSource("primary", false),
+            new StubDataSource("backup", true, throwOnLoad: true));
+
+        var act = async () => await fallback.LoadAsync("Missing", CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<FileNotFoundException>();
+        ex.Which.Message.Should().Contain("尝试结果");
+        ex.Which.Message.Should().Contain("not found");
+        ex.Which.Message.Should().Contain("backup load failed");
+    }
+
+    [Fact]
+    public async Task VersionedDataSource_Should_Filter_And_Map_Manifest_To_Logical_Names()
+    {
+        var inner = new StubDataSource(
+            "cdn",
+            true,
+            new DataSourceManifestEntry("v2/Hero", 20, hash: "hero-hash"),
+            new DataSourceManifestEntry("v1/Hero", 10, hash: "old-hash"),
+            new DataSourceManifestEntry("v2/Item", 30, version: "v2.1", hash: "item-hash"));
+        var versioned = new VersionedDataSource(inner, "v2");
+
+        var manifest = await versioned.GetManifestAsync(CancellationToken.None);
+
+        manifest.Version.Should().Be("v2");
+        manifest.Entries.Select(entry => entry.Name).Should().BeEquivalentTo("Hero", "Item");
+        manifest.Entries.Single(entry => entry.Name == "Hero").Version.Should().Be("v2");
+        manifest.Entries.Single(entry => entry.Name == "Hero").Hash.Should().Be("hero-hash");
+        manifest.Entries.Single(entry => entry.Name == "Item").Version.Should().Be("v2.1");
+    }
+
+    private sealed class StubDataSource : IDataSource
+    {
+        private readonly string _name;
+        private readonly bool _exists;
+        private readonly bool _throwOnLoad;
+        private readonly DataSourceManifest _manifest;
+
+        public StubDataSource(string name, bool exists, params DataSourceManifestEntry[] entries)
+            : this(name, exists, false, entries)
+        {
+        }
+
+        public StubDataSource(string name, bool exists, bool throwOnLoad, params DataSourceManifestEntry[] entries)
+        {
+            _name = name;
+            _exists = exists;
+            _throwOnLoad = throwOnLoad;
+            _manifest = new DataSourceManifest(entries, name);
+        }
+
+        public DataSourceType SourceType => DataSourceType.Memory;
+
+        public ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken)
+        {
+            if (_throwOnLoad)
+            {
+                throw new InvalidOperationException($"{_name} load failed");
+            }
+
+            return new ValueTask<byte[]>(new byte[] { 1, 2, 3 });
+        }
+
+        public ValueTask<bool> ExistsAsync(string name, CancellationToken cancellationToken) => new ValueTask<bool>(_exists);
+
+        public ValueTask<DataSourceManifest> GetManifestAsync(CancellationToken cancellationToken) => new ValueTask<DataSourceManifest>(_manifest);
+
+        public ValueTask<bool> IsAvailableAsync() => new ValueTask<bool>(true);
+
+        public override string ToString() => _name;
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve diagnostics and observability of the data-source pipeline so fallback loading and manifest merges indicate which source produced each entry. 
- Make versioned sources map physical versioned paths (e.g. `v2/Hero`) back to logical names while preserving per-entry version/hash for reliable manifest-based decisions. 
- Provide clearer failure messages when all data sources fail to help operations diagnose missing/failed sources.

### Description

- Add `SourceName` to `DataSourceManifestEntry` and expose it in both runtime and Unity copies by updating `src/DataTables/IDataSource.cs` and Unity counterpart. 
- Enhance `FallbackDataSource` to collect per-source attempt info, set `LastHitSource` on successful load, enrich merged manifests with `SourceName`, and include attempted-source details in the thrown `FileNotFoundException`. 
- Enhance `VersionedDataSource` to support a `manifestEntryMapper` and default mapping that filters version-prefixed entries and maps them back to logical names while preserving `Version` and `Hash`. 
- Add `docs/data-source-pipeline.md` documenting the transport-first model, manifest field semantics and fallback/versioned behavior, and add `tests/DataTables.Tests/DataSourcePipelineTests.cs` covering fallback diagnostics and versioned manifest mapping. 

### Testing

- `git diff --check` was run and returned no check failures. 
- `dotnet test tests/DataTables.Tests/DataTables.Tests.csproj` was attempted but not executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b49e3ec3c83318eb958f8ffbac4e7)