### PR TITLE
Reserve new table types (tree, graph) and add design docs for planned table types

### DIFF
--- a/docs/graph-table-design.md
+++ b/docs/graph-table-design.md
@@ -1,0 +1,153 @@
+# graph 表类型设计
+
+`graph` 是计划中的图结构配置表类型，适合表达节点与边组成的非树形关系，例如关卡拓扑、科技依赖、任务依赖、传送网络和状态机。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=graph` 给出“预留类型”诊断，而不是生成代码或数据。
+
+## 目标
+
+- 用可编辑表格表达节点和边的关系。
+- 支持有向图和无向图的基础建模。
+- 在生成期发现重复节点、非法边引用和不符合项目规则的环。
+- 生成强类型查询 API，支持按节点查询入边、出边和邻接节点。
+- 通过注册 parser、validator、writer 和模板实现，不在 `DataTableProcessor` 主流程中硬编码 graph 分支。
+
+## 推荐 Excel 格式
+
+graph 可以使用单 Sheet 双区域，也可以使用两个 Sheet。原型推荐两个 Sheet，便于策划维护。
+
+### 节点 Sheet
+
+| NodeId | NodeType | Name | Payload | Comment |
+| --- | --- | --- | --- | --- |
+| Start | state | 开始 | {} | 起点 |
+| Battle01 | battle | 第一场战斗 | {"monster":1001} | 战斗节点 |
+| Reward01 | reward | 奖励 | {"item":2001} | 奖励节点 |
+
+### 边 Sheet
+
+| EdgeId | From | To | EdgeType | Weight | Payload | Comment |
+| --- | --- | --- | --- | --- | --- | --- |
+| E001 | Start | Battle01 | next | 1 | {} | 起点到战斗 |
+| E002 | Battle01 | Reward01 | reward | 1 | {} | 战斗到奖励 |
+| E003 | Reward01 | Battle01 | retry | 5 | {} | 可选回退 |
+
+推荐约定：
+
+- `NodeId` 必填、唯一，并且作为节点主键。
+- `EdgeId` 必填、唯一；如果项目不需要边主键，可以由生成器按行号生成稳定 id。
+- `From` 和 `To` 必须引用存在的 `NodeId`。
+- `EdgeType` 可用于区分依赖、跳转、奖励、解锁等关系。
+- `Weight` 可选，用于寻路、排序或概率权重。
+- `Payload` 可选，用于存储边或节点扩展数据。
+
+## Sheet 元信息
+
+建议使用以下元信息声明：
+
+```text
+DTGen=graph,class=LevelGraph,namespace=Game.DataTables
+```
+
+如果使用两个 Sheet，可以约定：
+
+```text
+DTGen=graph,nodes=LevelGraphNodes,edges=LevelGraphEdges,class=LevelGraph
+```
+
+字段含义：
+
+- `DTGen=graph`：选择 graph 表生成器。
+- `class`：生成的图表类名。
+- `nodes`：节点 Sheet 名称。
+- `edges`：边 Sheet 名称。
+- `namespace`：生成代码命名空间；省略时使用默认命名空间。
+
+## 生成代码形态
+
+推荐生成节点、边和图查询 API：
+
+```csharp
+var node = DTLevelGraph.GetNode("Battle01");
+var outgoing = DTLevelGraph.GetOutgoingEdges("Battle01");
+var incoming = DTLevelGraph.GetIncomingEdges("Battle01");
+var neighbors = DTLevelGraph.GetNeighbors("Battle01");
+DTLevelGraph.TryGetEdge("E001", out var edge);
+```
+
+如果项目启用路径能力，可以额外生成工具 API：
+
+```csharp
+DTLevelGraph.HasPath("Start", "Reward01");
+DTLevelGraph.FindPath("Start", "Reward01");
+```
+
+路径 API 是否生成应由配置控制，避免为所有项目引入额外运行时成本。
+
+## 校验规则
+
+### 必须报错
+
+- `NodeId` 为空或重复。
+- `EdgeId` 为空或重复，且未启用自动生成边 id。
+- `From` 或 `To` 引用不存在的节点。
+- `Weight` 不是合法数字。
+- 项目声明为无环图时检测到环。
+- 业务字段或 JSON payload 不能按声明类型解析。
+
+### 可以警告
+
+- 节点没有任何入边或出边。
+- 存在从入口节点不可达的节点。
+- 同一对节点之间存在多条同类型边。
+- 权重为 0 或负数，但项目未禁止。
+
+## 诊断要求
+
+结构化诊断至少应包含：
+
+- severity
+- file
+- sheet
+- row
+- cell
+- nodeId
+- edgeId
+- from
+- to
+- field
+- errorCode
+- message
+
+非法边引用应指出边所在行、边 id、缺失的端点和端点字段名。环检测应输出构成环的节点路径。
+
+## 二进制 payload 建议
+
+推荐写出以下结构：
+
+1. 节点表：按稳定顺序写出节点数据。
+2. 边表：按稳定顺序写出边数据。
+3. 邻接索引：写出 `NodeId -> outgoing edge indexes` 和 `NodeId -> incoming edge indexes`。
+4. 可选入口节点列表：用于可达性校验和运行时快速入口查询。
+
+运行时加载后应避免临时扫描全边表来回答邻接查询。
+
+## 与索引和预热的关系
+
+- `NodeId` 和 `EdgeId` 是 graph 表的内建唯一索引。
+- `From` 和 `To` 是内建分组索引。
+- graph 表应参与显式表注册和 `PreheatAsync`。
+- 预热失败应暴露节点 id、边 id、端点和环路径等上下文。
+
+## 实现步骤建议
+
+1. 新增 `GraphTableParser`，支持节点区和边区解析，或支持节点 Sheet + 边 Sheet 组合解析。
+2. 新增 `GraphTableValidator`，实现唯一性、边引用、可达性和可选环检测。
+3. 新增 graph serialization plan 或 writer，写出节点表、边表和邻接索引。
+4. 新增 graph 代码生成模板，输出节点、边和图查询 API。
+5. 为 `DTGen=graph` 注册 parser、validator、writer 和模板。
+6. 增加正常图、重复节点、重复边、非法端点、不可达节点和环检测测试。
+
+## 非目标
+
+- 第一版不内置复杂图算法库；路径查询应作为可选能力。
+- 第一版不支持运行时动态增删节点或边。
+- 不通过修改 `DataTableProcessor` 主流程来硬编码 graph 分支。

--- a/docs/kv-table-design.md
+++ b/docs/kv-table-design.md
@@ -1,0 +1,140 @@
+# kv 表类型设计
+
+`kv` 是计划中的键值配置表类型，面向全局参数、功能开关、少量散列配置和不适合拆成多行记录的小型配置集合。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=kv` 给出“预留类型”诊断，而不是生成代码或数据。
+
+## 目标
+
+- 用统一格式表达全局参数和功能开关，避免为少量配置创建大量只有一行的数据表。
+- 复用现有 DataTables 类型系统，支持基础类型、枚举、数组、JSON 和自定义类型。
+- 生成强类型只读属性，减少业务代码中的字符串 key 查询。
+- 在生成期发现重复 key、非法类型和非法 value，降低运行时排错成本。
+- 保持 `DataTableProcessor` 编排路径稳定，通过注册新的 parser、validator、writer 和模板扩展实现。
+
+## 推荐 Excel 格式
+
+| Key | Type | Value | Comment |
+| --- | --- | --- | --- |
+| MaxLevel | int | 100 | 最大等级 |
+| EnablePvp | bool | true | 是否开启 PVP |
+| WelcomeText | string | 欢迎回来 | 登录欢迎文案 |
+| DefaultRewards | array<int> | 1001,1002,1003 | 默认奖励 ID |
+| FeatureWeights | map<string,int> | pve:10,pvp:5 | 功能权重 |
+| ExtraConfig | json<GameConfig> | {"dailyLimit":3} | 扩展 JSON 配置 |
+
+推荐约定：
+
+- `Key` 必填、唯一，并且应是合法 C# 成员名；如果允许点号或短横线，生成器必须提供确定性的成员名转换规则。
+- `Type` 必填，语法与普通字段类型保持一致。
+- `Value` 必填；如果业务确实需要空值，应通过显式 nullable 或约定默认值表达。
+- `Comment` 可选，只用于说明，不进入运行时 payload。
+
+## Sheet 元信息
+
+建议使用以下元信息声明：
+
+```text
+DTGen=kv,class=GameConfig,namespace=Game.DataTables
+```
+
+字段含义：
+
+- `DTGen=kv`：选择 kv 表生成器。
+- `class`：生成的配置类名；示例会生成 `DTGameConfig` 或项目配置的前缀形态。
+- `namespace`：生成代码命名空间；如果省略，则使用生成器默认命名空间。
+
+## 生成代码形态
+
+推荐生成只读静态属性或只读实例属性，具体取决于项目现有表访问模式。示例：
+
+```csharp
+var maxLevel = DTGameConfig.MaxLevel;
+var enablePvp = DTGameConfig.EnablePvp;
+var rewards = DTGameConfig.DefaultRewards;
+```
+
+当需要保留动态访问能力时，可以额外生成：
+
+```csharp
+DTGameConfig.TryGetValue("MaxLevel", out var value);
+DTGameConfig.GetValue<int>("MaxLevel");
+```
+
+动态访问 API 只作为工具或兼容场景使用；业务代码应优先使用强类型属性。
+
+## 类型与值解析
+
+`kv` 应复用现有 `DataTypeParser` 和各类型 `DataProcessor`：
+
+- 基础类型：`int`、`long`、`float`、`double`、`bool`、`string` 等。
+- 枚举：按现有 enum 类型处理规则解析。
+- 数组：例如 `array<int>`。
+- 映射：例如 `map<string,int>`。
+- JSON：例如 `json<GameConfig>`。
+- 自定义类型：例如 `custom<MyStruct>`，由项目注册的处理器负责。
+
+生成器应在写出 `.bytes` 前完成 value 解析和校验，避免运行时首次加载时才发现格式错误。
+
+## 校验规则
+
+### 必须报错
+
+- `Key` 为空。
+- `Key` 重复。
+- `Key` 无法转换为合法生成成员名，且没有配置显式别名。
+- `Type` 为空或不是受支持类型。
+- `Value` 不能按 `Type` 成功解析。
+- JSON value 不是合法 JSON，或不能映射到声明的 JSON 目标类型。
+
+### 可以警告
+
+- `Key` 命名不符合项目推荐风格。
+- `Comment` 为空。
+- `Value` 使用了兼容模式才允许的旧格式。
+- 动态访问 key 与生成属性名发生大小写或符号归一化冲突。
+
+## 诊断要求
+
+诊断应使用结构化格式，并至少包含：
+
+- severity
+- file
+- sheet
+- row
+- cell
+- key
+- field
+- errorCode
+- message
+
+重复 key 的错误消息应同时指出首次出现行和重复出现行，便于策划直接定位 Excel。
+
+## 二进制 payload 建议
+
+kv payload 可以采用确定性顺序写出：
+
+1. 按 Excel 行顺序或按 key 排序写出条目；推荐默认保持 Excel 行顺序，便于诊断和 diff。
+2. 每个条目写出 key、类型签名和 value payload。
+3. 结构化 header 继续使用 v3 header、schema hash、generator version、table full name 和 flags。
+
+如果最终生成代码只使用强类型属性，运行时也应保留 key 到 value 的元数据，方便调试工具和兼容 API 查询。
+
+## 与索引和预热的关系
+
+- kv 表不需要普通行表索引；`Key` 本身就是唯一键。
+- kv 表应参与显式表注册和 `PreheatAsync`，以便服务端或客户端启动时提前校验配置。
+- 预热失败应暴露具体 key 和 value 解析错误，而不是只报告表加载失败。
+
+## 实现步骤建议
+
+1. 新增 `KvTableParser`，从固定列 `Key`、`Type`、`Value`、`Comment` 解析 kv schema。
+2. 新增 `KvTableValidator`，实现 key 唯一性、成员名、类型和值校验。
+3. 新增 kv serialization plan 或 writer，避免把 kv payload 写出逻辑放进 `DataTableProcessor`。
+4. 新增 kv 代码生成模板，输出强类型属性和可选动态访问 API。
+5. 为 `DTGen=kv` 注册 parser、validator、writer 和模板。
+6. 增加 kv 正常生成、重复 key、非法类型、非法 value、嵌套类型和 JSON 的测试。
+
+## 非目标
+
+- 不在第一版支持复杂表达式或公式语言。
+- 不把 kv 表设计成可变运行时配置；运行时 API 默认只读。
+- 不通过修改 `DataTableProcessor` 主流程来硬编码 kv 分支。

--- a/docs/localized-table-design.md
+++ b/docs/localized-table-design.md
@@ -1,0 +1,85 @@
+# localized 表类型设计
+
+`localized` 是计划中的多语言文本资源表类型。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=localized` 给出“预留类型”诊断，而不是生成代码或数据。
+
+## 目标
+
+- 把多语言翻译集中在一张便于策划和本地化团队维护的表中。
+- 生成强类型查询 API，减少业务代码中的裸字符串调用。
+- 支持确定性的语言 fallback。
+- 支持客户端只加载当前语言，也支持工具或服务端一次性加载全部语言。
+- 支持服务端按单语言导出或按全语言导出。
+
+## 推荐 Excel 格式
+
+| Key | zh-CN | en-US | ja-JP | Comment |
+| --- | --- | --- | --- | --- |
+| Ui.Start | 开始 | Start | スタート | 主菜单开始按钮 |
+| Ui.Quit | 退出 | Quit | 終了 | 主菜单退出按钮 |
+| Item.Sword.Name | 铁剑 | Iron Sword | 鉄の剣 | 道具显示名 |
+
+规则：
+
+- `Key` 必填、唯一，并且应在版本迭代中保持稳定。
+- 语言列使用 BCP-47 风格命名，例如 `en-US`、`zh-CN`。
+- `Comment` 为可选说明列；除非启用调试导出模式，否则不进入运行时 payload。
+- 翻译单元格允许为空，但前提是 fallback 链能解析出可用文本。
+
+## 生成代码形态
+
+生成表应同时提供基于 key 的查询 API 和便捷查询 API：
+
+```csharp
+DTLocalization.Get("Ui.Start");
+DTLocalization.Get("Ui.Start", language: "en-US");
+DTLocalization.TryGet("Ui.Start", out var value);
+```
+
+可选生成常量用于减少调用处的裸字符串：
+
+```csharp
+DTLocalization.Keys.Ui_Start
+```
+
+## 运行时查询与 fallback
+
+运行时应按以下顺序解析文本：
+
+1. 查询调用中显式传入的语言。
+2. localization 表或 manager 当前配置的运行时语言。
+3. 项目默认语言。
+4. 如果项目配置了 invariant fallback 列，则使用该列。
+
+严格模式下，缺失 key 应视为错误；缺失某语言翻译时，只有在 fallback 链无法解析出文本时才视为错误。
+
+## 加载模式
+
+### 当前语言加载
+
+客户端构建可以只加载一个语言 payload，以降低内存占用。该模式推荐用于移动端和文本量较大的游戏客户端。
+
+### 全语言加载
+
+工具、测试、专用服务器和构建校验可以加载全部语言，用于完整性检查或下游资源导出。
+
+## 服务端导出模式
+
+服务端流水线应支持：
+
+- `--language en-US`：只导出单个语言。
+- `--all-languages`：导出所有语言列。
+- `--validate-fallbacks`：当配置的 fallback 链无法产生可用文本时让构建失败。
+
+## 诊断
+
+实现时应输出结构化诊断，并至少包含文件、Sheet、单元格、key、语言、错误码和消息。重要诊断包括：
+
+- 本地化 key 重复。
+- 语言列名非法。
+- 默认语言文本缺失。
+- 翻译缺失且没有 fallback 可用。
+- 不同语言之间的占位符不一致。
+
+## 实现说明
+
+`localized` 应作为普通注册式表 parser、validator 和 writer 实现。新增该类型时，不应在 `DataTableProcessor` 编排路径中加入特殊分支。

--- a/docs/table-types.md
+++ b/docs/table-types.md
@@ -1,0 +1,80 @@
+# DataTables 表类型
+
+本文档说明当前已支持和计划中的表格布局。表类型由 Sheet 元信息行中的 `DTGen` 值选择。
+
+## 已支持类型
+
+### `table`
+
+面向行的数据表。每一行数据都会生成一个行对象，并且可以参与索引构建。
+
+推荐场景：
+
+- 道具表
+- 怪物表
+- 等级曲线
+- 客户端与服务端共享配置
+
+### `matrix`
+
+面向矩阵的数据表。行坐标和列坐标都具备业务含义。
+
+推荐场景：
+
+- 二维数值平衡表
+- 关系矩阵
+- 由两个维度共同定位的消耗表
+
+### `column`
+
+面向列的数据表。适合把一个逻辑记录纵向存放，而不是横向存放。
+
+推荐场景：
+
+- 更便于编辑器填写的小型配置表
+- 字段较多、说明列较多或本地化列较多的小表
+
+## 预留原型类型
+
+解析器注册表会有意预留部分类型名称。这样项目使用尚未实现的表类型时，可以得到明确诊断，而不是静默回退到 `table` 语义。
+
+### `kv`
+
+`kv` 计划用于全局参数、功能开关和少量散列配置。完整原型设计见 [kv 表类型设计](kv-table-design.md)。推荐 Excel 结构如下：
+
+| Key | Type | Value | Comment |
+| --- | --- | --- | --- |
+| MaxLevel | int | 100 | 最大等级 |
+| EnablePvp | bool | true | 是否开启 PVP |
+| DropRates | array<int> | 1,2,3 | 示例数组值 |
+| ExtraJson | json<GameConfig> | {"foo":1} | JSON 载荷 |
+
+计划生成的强类型 API 形态：
+
+```csharp
+DTGameConfig.MaxLevel
+DTGameConfig.EnablePvp
+```
+
+计划校验规则：
+
+- `Key` 必须唯一，并且必须是合法的生成成员名。
+- `Type` 复用普通字段的 DataTables 类型解析器。
+- `Value` 在写出 `.bytes` 前必须使用所选类型处理器完成校验。
+- 严格模式下，重复 key 和非法 value 应报告为生成错误；兼容模式可以把部分发现降级为警告。
+
+### `localized`
+
+`localized` 计划用于多语言文本资源。详细设计见 [localized 表类型设计](localized-table-design.md)。
+
+### `tree`
+
+`tree` 计划用于树形层级配置，例如章节、任务链、技能树和菜单结构。完整原型设计见 [tree 表类型设计](tree-table-design.md)。
+
+### `graph`
+
+`graph` 计划用于节点与边组成的图结构配置，例如关卡拓扑、科技依赖、传送网络和状态机。完整原型设计见 [graph 表类型设计](graph-table-design.md)。
+
+### 其他预留名称
+
+`partitioned`、`versioned` 和 `patch` 预留给未来的运行时加载、热更新和补丁场景；它们目前还不是已实现的表生成器。

--- a/docs/tree-table-design.md
+++ b/docs/tree-table-design.md
@@ -1,0 +1,128 @@
+# tree 表类型设计
+
+`tree` 是计划中的树形配置表类型，适合表达有父子层级关系的数据，例如章节目录、任务链、技能树、菜单结构和组织结构。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=tree` 给出“预留类型”诊断，而不是生成代码或数据。
+
+## 目标
+
+- 用表格方式表达稳定的父子层级关系。
+- 在生成期发现孤儿节点、重复节点、循环引用和非法根节点。
+- 生成强类型查询 API，支持按节点、父节点、子节点和根节点查询。
+- 支持客户端或服务端预热时提前校验完整树结构。
+- 通过注册 parser、validator、writer 和模板实现，不在 `DataTableProcessor` 主流程中硬编码 tree 分支。
+
+## 推荐 Excel 格式
+
+| Id | ParentId | Order | Name | Type | Payload | Comment |
+| --- | --- | --- | --- | --- | --- | --- |
+| Root |  | 0 | 主线 | chapter | {} | 根节点 |
+| Chapter01 | Root | 10 | 第一章 | chapter | {} | 章节节点 |
+| Quest001 | Chapter01 | 10 | 初始任务 | quest | {"level":1} | 任务节点 |
+| Quest002 | Chapter01 | 20 | 进阶任务 | quest | {"level":2} | 任务节点 |
+
+推荐约定：
+
+- `Id` 必填、唯一，并且作为树节点主键。
+- `ParentId` 为空表示根节点；非空时必须引用已存在的 `Id`。
+- `Order` 可选，用于同级节点排序；为空时按 Excel 行顺序排序。
+- `Name`、`Type`、`Payload` 为业务字段，可以按项目需要扩展。
+- `Comment` 可选，只用于说明，不进入运行时 payload。
+
+## Sheet 元信息
+
+建议使用以下元信息声明：
+
+```text
+DTGen=tree,class=QuestTree,namespace=Game.DataTables
+```
+
+字段含义：
+
+- `DTGen=tree`：选择 tree 表生成器。
+- `class`：生成的树表类名。
+- `namespace`：生成代码命名空间；省略时使用默认命名空间。
+
+## 生成代码形态
+
+推荐生成节点类型和树表查询 API：
+
+```csharp
+var rootNodes = DTQuestTree.Roots;
+var node = DTQuestTree.GetById("Quest001");
+var children = DTQuestTree.GetChildren("Chapter01");
+var parent = DTQuestTree.GetParent("Quest001");
+DTQuestTree.TryGetById("Quest002", out var questNode);
+```
+
+如果业务需要遍历，可以额外生成：
+
+```csharp
+foreach (var node in DTQuestTree.TraverseDepthFirst("Root"))
+{
+    // visit node
+}
+```
+
+## 校验规则
+
+### 必须报错
+
+- `Id` 为空或重复。
+- `ParentId` 引用不存在的节点。
+- 任意节点形成循环引用。
+- 根节点数量不符合 Sheet 或项目配置要求。
+- `Order` 不是合法数字。
+- 业务字段不能按声明类型解析。
+
+### 可以警告
+
+- 同一父节点下多个子节点 `Order` 相同。
+- 存在未被业务入口引用的孤立根节点，但配置允许多根。
+- 节点深度超过项目推荐上限。
+
+## 诊断要求
+
+结构化诊断至少应包含：
+
+- severity
+- file
+- sheet
+- row
+- cell
+- nodeId
+- parentId
+- field
+- errorCode
+- message
+
+循环引用诊断应输出完整路径，例如 `A -> B -> C -> A`，便于策划定位链路。
+
+## 二进制 payload 建议
+
+推荐写出两类数据：
+
+1. 节点顺序表：按 Excel 行顺序或稳定排序写出完整节点数据。
+2. 关系索引：写出 `Id -> index`、`ParentId -> child indexes` 和根节点索引列表。
+
+运行时加载时应能直接构建父子查询结构，避免每次查询都扫描全表。
+
+## 与索引和预热的关系
+
+- `Id` 是 tree 表的内建唯一索引。
+- `ParentId` 是内建分组索引。
+- tree 表应参与显式表注册和 `PreheatAsync`。
+- 预热失败应暴露节点 id、父节点 id 和循环路径等上下文。
+
+## 实现步骤建议
+
+1. 新增 `TreeTableParser`，识别固定列 `Id`、`ParentId`、`Order` 和业务字段。
+2. 新增 `TreeTableValidator`，实现唯一性、引用完整性和循环检测。
+3. 新增 tree serialization plan 或 writer，写出节点数据和关系索引。
+4. 新增 tree 代码生成模板，输出节点类型和树查询 API。
+5. 为 `DTGen=tree` 注册 parser、validator、writer 和模板。
+6. 增加正常树、多根树、孤儿节点、重复节点和循环引用测试。
+
+## 非目标
+
+- 第一版不支持运行时动态增删节点。
+- 第一版不支持跨表父子引用；跨表关系应由业务层或后续 graph 表类型处理。
+- 不通过修改 `DataTableProcessor` 主流程来硬编码 tree 分支。

--- a/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
+++ b/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
@@ -10,6 +10,8 @@ public sealed class TableSchemaParserRegistry : ITableSchemaParserRegistry
     [
         "kv",
         "localized",
+        "tree",
+        "graph",
         "partitioned",
         "versioned",
         "patch"

--- a/tests/DataTables.Tests/ParserTests.cs
+++ b/tests/DataTables.Tests/ParserTests.cs
@@ -188,7 +188,7 @@ public class ParserTests
 		diagnostic.Cell.Should().Be("A1");
 		diagnostic.Message.Should().Contain("声明值: kv");
 		diagnostic.Message.Should().Contain("支持的类型: column, matrix, table");
-		diagnostic.Message.Should().Contain("预留类型: kv, localized, partitioned, versioned, patch");
+		diagnostic.Message.Should().Contain("预留类型: kv, localized, tree, graph, partitioned, versioned, patch");
 	}
 
 }


### PR DESCRIPTION
### Motivation

- Reserve the identifiers for planned table generators so the parser can emit explicit "reserved type" diagnostics rather than silently falling back to `table` semantics. 
- Provide design documentation for several planned table kinds to guide future implementation and maintainers. 
- Update tests to reflect the expanded set of reserved types reported in diagnostics.

### Description

- Added design documents for planned table types: `kv`, `localized`, `tree`, `graph`, and a summary `table-types` overview under `docs/`.
- Extended the reserved dataset types list in `TableSchemaParserRegistry` to include `tree` and `graph` so they appear in diagnostics.
- Updated the unit test expectation in `ParserTests.CreateGenerationContext_Should_Report_Unknown_DTGen_Type` to include the new reserved names in the diagnostic message.

### Testing

- Ran the unit test suite containing `ParserTests`, including `CreateGenerationContext_Should_Report_Unknown_DTGen_Type`, and it passed after updating the expected diagnostic string. 
- Executed `dotnet test` for the test project and observed a successful run with the modified assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b4c7f34a0833189ecbdf614b701c4)