### PR TITLE
Implement DTGen=tree: parser, validator, binary check and codegen

### DIFF
--- a/src/DataTables.GeneratorCore/CodeGen/CodeTemplateRendererRegistry.cs
+++ b/src/DataTables.GeneratorCore/CodeGen/CodeTemplateRendererRegistry.cs
@@ -26,6 +26,7 @@ internal sealed class CodeTemplateRendererRegistry
             new DataMatrixCodeTemplateRenderer(),
             new DataTableCodeTemplateRenderer("column"),
             new KvTableCodeTemplateRenderer(),
+            new TreeTableCodeTemplateRenderer(),
         ]);
     }
 

--- a/src/DataTables.GeneratorCore/CodeGen/TreeTableCodeTemplateRenderer.cs
+++ b/src/DataTables.GeneratorCore/CodeGen/TreeTableCodeTemplateRenderer.cs
@@ -1,0 +1,11 @@
+namespace DataTables.GeneratorCore;
+
+internal sealed class TreeTableCodeTemplateRenderer : ICodeTemplateRenderer
+{
+    public string DataSetType => "tree";
+
+    public string TransformText(GenerationContext context)
+    {
+        return new TreeTableTemplate(context).TransformText();
+    }
+}

--- a/src/DataTables.GeneratorCore/DataTableProcessor.cs
+++ b/src/DataTables.GeneratorCore/DataTableProcessor.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using NPOI.SS.UserModel;
@@ -468,9 +469,94 @@ public sealed partial class DataTableProcessor : IDisposable
         new DataTableBinaryWriter(m_Context, WriteDataRows).GenerateDataFile(filePath, outputDir, forceOverwrite, sheet, logger);
     }
 
+    private void ValidateTreeRows(ISheet sheet)
+    {
+        var idField = m_Context.GetField("Id") ?? throw new InvalidOperationException("DTGen=tree 缺少 Id 字段");
+        var parentField = m_Context.GetField("ParentId") ?? throw new InvalidOperationException("DTGen=tree 缺少 ParentId 字段");
+        var orderField = m_Context.GetField("Order");
+        var nodes = new Dictionary<string, (string ParentId, int Row)>(StringComparer.Ordinal);
+
+        for (int i = m_FirstDataRowIndex; i <= sheet.LastRowNum; i++)
+        {
+            var row = sheet.GetRow(i);
+            if (!IgnoreDataRow(row))
+            {
+                continue;
+            }
+
+            var id = GetCellString(row!.GetCell(idField.Index));
+            var parentId = GetCellString(row.GetCell(parentField.Index));
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new FormatException($"DTGen=tree Id 为空: row={i + 1}, cell={GetRowColString(i, idField.Index)}");
+            }
+
+            if (!nodes.TryAdd(id, (parentId, i)))
+            {
+                throw new FormatException($"DTGen=tree Id 重复: nodeId={id}, row={i + 1}, cell={GetRowColString(i, idField.Index)}");
+            }
+
+            if (orderField != null)
+            {
+                var orderText = GetCellString(row.GetCell(orderField.Index));
+                if (!string.IsNullOrWhiteSpace(orderText) && !decimal.TryParse(orderText, out _))
+                {
+                    throw new FormatException($"DTGen=tree Order 不是合法数字: nodeId={id}, row={i + 1}, cell={GetRowColString(i, orderField.Index)}, value={orderText}");
+                }
+            }
+        }
+
+        foreach (var (id, node) in nodes)
+        {
+            if (string.IsNullOrEmpty(node.ParentId))
+            {
+                continue;
+            }
+
+            if (!nodes.ContainsKey(node.ParentId))
+            {
+                throw new FormatException($"DTGen=tree ParentId 引用不存在: nodeId={id}, parentId={node.ParentId}, row={node.Row + 1}");
+            }
+        }
+
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var visiting = new HashSet<string>(StringComparer.Ordinal);
+        var path = new List<string>();
+        foreach (var id in nodes.Keys)
+        {
+            Visit(id);
+        }
+
+        void Visit(string id)
+        {
+            if (visited.Contains(id)) return;
+            if (!visiting.Add(id))
+            {
+                var start = path.IndexOf(id);
+                var cycle = start >= 0 ? path.Skip(start).Concat(new[] { id }) : new[] { id, id };
+                throw new FormatException($"DTGen=tree 检测到循环引用: {string.Join(" -> ", cycle)}");
+            }
+
+            path.Add(id);
+            var parentId = nodes[id].ParentId;
+            if (!string.IsNullOrEmpty(parentId) && nodes.ContainsKey(parentId))
+            {
+                Visit(parentId);
+            }
+            path.RemoveAt(path.Count - 1);
+            visiting.Remove(id);
+            visited.Add(id);
+        }
+    }
+
     private int WriteDataRows(ISheet sheet, BinaryWriter writer)
     {
         int dataRowCount = 0;
+
+        if (m_Context.DataSetType == "tree")
+        {
+            ValidateTreeRows(sheet);
+        }
 
         if (m_Context.DataSetType == "kv")
         {

--- a/src/DataTables.GeneratorCore/Schema/TreeTableParser.cs
+++ b/src/DataTables.GeneratorCore/Schema/TreeTableParser.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+
+namespace DataTables.GeneratorCore;
+
+public sealed class TreeTableParser : ITableSchemaParser
+{
+    private readonly RowTableParser m_RowTableParser = new();
+
+    public string DataSetType => "tree";
+
+    public int Parse(ISheetReader sheet, GenerationContext context, ParseOptions options, DiagnosticsCollector diagnostics)
+    {
+        var firstDataRowIndex = m_RowTableParser.Parse(sheet, context, options, diagnostics);
+        if (firstDataRowIndex == -1)
+        {
+            return -1;
+        }
+
+        RequireField(context, "Id");
+        RequireField(context, "ParentId");
+
+        EnsureStringField(context, "Id");
+        EnsureStringField(context, "ParentId");
+
+        if (context.GetField("Order") is { } orderField)
+        {
+            var typeName = (orderField.TypeName ?? string.Empty).Trim();
+            if (typeName.Length == 0)
+            {
+                orderField.TypeName = "int";
+            }
+        }
+
+        AddBuiltInIndex(context.Indexs, "Id");
+        AddBuiltInIndex(context.Groups, "ParentId");
+
+        return firstDataRowIndex;
+    }
+
+    private static void RequireField(GenerationContext context, string fieldName)
+    {
+        if (context.GetField(fieldName) == null)
+        {
+            var available = string.Join(", ", context.Fields.Where(x => !x.IsIgnore).Select(x => x.Name));
+            throw new FormatException($"DTGen=tree 缺少必需字段 {fieldName}. 可用字段: [{available}]");
+        }
+    }
+
+    private static void EnsureStringField(GenerationContext context, string fieldName)
+    {
+        var field = context.GetField(fieldName)!;
+        var typeName = (field.TypeName ?? string.Empty).Trim();
+        if (typeName.Length == 0)
+        {
+            field.TypeName = "string";
+            return;
+        }
+
+        if (!typeName.Equals("string", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new FormatException($"DTGen=tree 字段 {fieldName} 必须声明为 string，当前为 {field.TypeName}");
+        }
+    }
+
+    private static void AddBuiltInIndex(System.Collections.Generic.List<string[]> collection, string fieldName)
+    {
+        if (!collection.Any(x => x.Length == 1 && x[0].Equals(fieldName, StringComparison.Ordinal)))
+        {
+            collection.Add([fieldName]);
+        }
+    }
+}

--- a/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
+++ b/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
@@ -9,6 +9,7 @@ public sealed class TableSchemaParserRegistry : ITableSchemaParserRegistry
     private static readonly string[] s_ReservedDataSetTypes =
     [
         "localized",
+        "tree",
         "graph",
         "partitioned",
         "versioned",

--- a/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
+++ b/src/DataTables.GeneratorCore/TableSchemaParserRegistry.cs
@@ -9,7 +9,6 @@ public sealed class TableSchemaParserRegistry : ITableSchemaParserRegistry
     private static readonly string[] s_ReservedDataSetTypes =
     [
         "localized",
-        "tree",
         "graph",
         "partitioned",
         "versioned",
@@ -35,7 +34,8 @@ public sealed class TableSchemaParserRegistry : ITableSchemaParserRegistry
             new RowTableParser(),
             new MatrixTableParser(),
             new ColumnTableParser(),
-            new KvTableParser()
+            new KvTableParser(),
+            new TreeTableParser()
         ]);
     }
 

--- a/src/DataTables.GeneratorCore/TreeTableTemplate.cs
+++ b/src/DataTables.GeneratorCore/TreeTableTemplate.cs
@@ -1,0 +1,75 @@
+namespace DataTables.GeneratorCore;
+
+using System;
+using System.Linq;
+using System.Text;
+
+public sealed class TreeTableTemplate : DataTableTemplate
+{
+    public TreeTableTemplate(GenerationContext generationContext) : base(generationContext)
+    {
+    }
+
+    public override string TransformText()
+    {
+        var sb = new StringBuilder(base.TransformText());
+        var marker = "    #endregion" + Environment.NewLine + "}";
+        var insert = BuildTreeApi();
+        var text = sb.ToString();
+        var idx = text.IndexOf(marker, StringComparison.Ordinal);
+        return idx < 0 ? text : text.Insert(idx, insert);
+    }
+
+    private string BuildTreeApi()
+    {
+        var row = GenerationContext.DataRowClassName;
+        var table = GenerationContext.DataTableClassName;
+        var sb = new StringBuilder();
+        void WL(string text = "") => sb.AppendLine(text);
+
+        WL();
+        WL("    #region Tree API");
+        WL($"    public IReadOnlyList<{row}> GetRoots() => GetManyByParentId(string.Empty) ?? Array.Empty<{row}>();");
+        WL();
+        WL("    [MethodImpl(MethodImplOptions.AggressiveInlining)]");
+        WL($"    public IReadOnlyList<{row}>? GetChildren(string id) => GetManyByParentId(id);");
+        WL();
+        WL("    [MethodImpl(MethodImplOptions.AggressiveInlining)]");
+        WL($"    public {row}? GetParent(string id)");
+        WL("    {");
+        WL("        var node = GetById(id);");
+        WL("        return node == null || string.IsNullOrEmpty(node.ParentId) ? null : GetById(node.ParentId);");
+        WL("    }");
+        WL();
+        WL($"    public IEnumerable<{row}> TraverseDepthFirst(string id)");
+        WL("    {");
+        WL("        var root = GetById(id);");
+        WL("        if (root == null) yield break;");
+        WL("        var stack = new Stack<IEnumerator<" + row + ">>();");
+        WL("        yield return root;");
+        WL("        stack.Push((GetChildren(root.Id) ?? Array.Empty<" + row + ">()).Reverse().GetEnumerator());");
+        WL("        while (stack.Count > 0)");
+        WL("        {");
+        WL("            var it = stack.Peek();");
+        WL("            if (!it.MoveNext())");
+        WL("            {");
+        WL("                it.Dispose();");
+        WL("                stack.Pop();");
+        WL("                continue;");
+        WL("            }");
+        WL("            var current = it.Current;");
+        WL("            yield return current;");
+        WL("            stack.Push((GetChildren(current.Id) ?? Array.Empty<" + row + ">()).Reverse().GetEnumerator());");
+        WL("        }");
+        WL("    }");
+        WL();
+        WL($"    public static IReadOnlyList<{row}> Roots => DataTableManager.GetDataTableInternal<{table}>()?.GetRoots() ?? Array.Empty<{row}>();");
+        WL($"    public static IReadOnlyList<{row}> StaticRoots => Roots;");
+        WL($"    public static IReadOnlyList<{row}> RootsStatic => Roots;");
+        WL($"    public static IReadOnlyList<{row}>? GetChildrenStatic(string id) => DataTableManager.GetDataTableInternal<{table}>()?.GetChildren(id);");
+        WL($"    public static {row}? GetParentStatic(string id) => DataTableManager.GetDataTableInternal<{table}>()?.GetParent(id);");
+        WL($"    public static IEnumerable<{row}> TraverseDepthFirstStatic(string id) => DataTableManager.GetDataTableInternal<{table}>()?.TraverseDepthFirst(id) ?? Array.Empty<{row}>();");
+        WL("    #endregion");
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
### Motivation
- Add support for the planned `tree` table type so spreadsheets can express parent/child hierarchies with generation-time validation and runtime query APIs.
- Detect structural problems (missing/duplicate Id, missing parents, cycles, invalid Order) during generation and produce strong-typed accessors in generated code.

### Description
- Register `TreeTableParser` and `TreeTableCodeTemplateRenderer` so `DTGen=tree` is a supported dataset type and code renderer (changes in `TableSchemaParserRegistry.cs` and `CodeTemplateRendererRegistry.cs`).
- Add `TreeTableParser` that reuses row parsing, requires `Id`/`ParentId`, ensures their types are `string`, sets default `Order` to `int` when missing, and injects built-in `Id` unique index and `ParentId` group index (`src/DataTables.GeneratorCore/Schema/TreeTableParser.cs`).
- Add runtime generation-time validation in `DataTableProcessor.ValidateTreeRows` to check empty/duplicate `Id`, non-numeric `Order`, missing parent references, and detect cycles with a diagnostic path, and call it before writing binary data (`src/DataTables.GeneratorCore/DataTableProcessor.cs`).
- Add a `TreeTableTemplate` to extend generated C# templates with tree APIs including roots, children, parent lookup, depth-first traversal, and static accessors (`src/DataTables.GeneratorCore/TreeTableTemplate.cs` and `src/DataTables.GeneratorCore/CodeGen/TreeTableCodeTemplateRenderer.cs`).

### Testing
- Attempted to run unit tests with `dotnet test DataTables.sln --no-restore`, but the command could not execute because `dotnet` is not installed in the current environment (no automated test run performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b74a0edbc8331b648afca0c666fd4)