### PR TITLE
docs: update table-type status and refresh kv/tree documentation

### DIFF
--- a/docs/kv-table-design.md
+++ b/docs/kv-table-design.md
@@ -1,14 +1,14 @@
 # kv 表类型设计
 
-`kv` 是计划中的键值配置表类型，面向全局参数、功能开关、少量散列配置和不适合拆成多行记录的小型配置集合。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=kv` 给出“预留类型”诊断，而不是生成代码或数据。
+`kv` 是已实现的键值配置表类型，面向全局参数、功能开关、少量散列配置和不适合拆成多行记录的小型配置集合。当前生成器会解析 `DTGen=kv`，生成强类型静态属性，并提供 `TryGetValue<T>` / `GetValue<T>` 动态读取 API。
 
 ## 目标
 
 - 用统一格式表达全局参数和功能开关，避免为少量配置创建大量只有一行的数据表。
 - 复用现有 DataTables 类型系统，支持基础类型、枚举、数组、JSON 和自定义类型。
 - 生成强类型只读属性，减少业务代码中的字符串 key 查询。
-- 在生成期发现重复 key、非法类型和非法 value，降低运行时排错成本。
-- 保持 `DataTableProcessor` 编排路径稳定，通过注册新的 parser、validator、writer 和模板扩展实现。
+- 在生成期发现重复 key、非法成员名、非法类型和不可写出的非法 value，降低运行时排错成本。
+- 保持 `DataTableProcessor` 编排路径稳定，通过已注册的 parser 和模板扩展实现。
 
 ## 推荐 Excel 格式
 
@@ -23,7 +23,7 @@
 
 推荐约定：
 
-- `Key` 必填、唯一，并且应是合法 C# 成员名；如果允许点号或短横线，生成器必须提供确定性的成员名转换规则。
+- `Key` 必填、唯一，并且必须匹配 `^[A-Za-z][A-Za-z0-9_]*$`；当前不会把点号、短横线等字符转换为成员名。
 - `Type` 必填，语法与普通字段类型保持一致。
 - `Value` 必填；如果业务确实需要空值，应通过显式 nullable 或约定默认值表达。
 - `Comment` 可选，只用于说明，不进入运行时 payload。
@@ -44,7 +44,7 @@ DTGen=kv,class=GameConfig,namespace=Game.DataTables
 
 ## 生成代码形态
 
-推荐生成只读静态属性或只读实例属性，具体取决于项目现有表访问模式。示例：
+当前实现会为每个 key 生成同名只读静态属性。示例：
 
 ```csharp
 var maxLevel = DTGameConfig.MaxLevel;
@@ -52,18 +52,19 @@ var enablePvp = DTGameConfig.EnablePvp;
 var rewards = DTGameConfig.DefaultRewards;
 ```
 
-当需要保留动态访问能力时，可以额外生成：
+当前实现还会生成动态访问 API：
 
 ```csharp
-DTGameConfig.TryGetValue("MaxLevel", out var value);
-DTGameConfig.GetValue<int>("MaxLevel");
+var table = DataTableManager.GetDataTable<DTGameConfig>();
+table?.TryGetValue("MaxLevel", out int? value);
+table?.GetValue<int>("MaxLevel");
 ```
 
 动态访问 API 只作为工具或兼容场景使用；业务代码应优先使用强类型属性。
 
 ## 类型与值解析
 
-`kv` 应复用现有 `DataTypeParser` 和各类型 `DataProcessor`：
+`kv` 复用现有字段类型解析和各类型 `DataProcessor`：
 
 - 基础类型：`int`、`long`、`float`、`double`、`bool`、`string` 等。
 - 枚举：按现有 enum 类型处理规则解析。
@@ -72,29 +73,27 @@ DTGameConfig.GetValue<int>("MaxLevel");
 - JSON：例如 `json<GameConfig>`。
 - 自定义类型：例如 `custom<MyStruct>`，由项目注册的处理器负责。
 
-生成器应在写出 `.bytes` 前完成 value 解析和校验，避免运行时首次加载时才发现格式错误。
+生成器会在解析阶段检查类型声明是否合法；具体 value 会作为内部单行数据在后续写出流程中按声明类型处理。
 
-## 校验规则
+## 当前校验规则
 
 ### 必须报错
 
 - `Key` 为空。
 - `Key` 重复。
-- `Key` 无法转换为合法生成成员名，且没有配置显式别名。
+- `Key` 不匹配 `^[A-Za-z][A-Za-z0-9_]*$`。
 - `Type` 为空或不是受支持类型。
 - `Value` 不能按 `Type` 成功解析。
-- JSON value 不是合法 JSON，或不能映射到声明的 JSON 目标类型。
 
-### 可以警告
+### 后续可增强
 
-- `Key` 命名不符合项目推荐风格。
-- `Comment` 为空。
-- `Value` 使用了兼容模式才允许的旧格式。
-- 动态访问 key 与生成属性名发生大小写或符号归一化冲突。
+- 更细粒度地报告 JSON value 与声明目标类型不匹配。
+- 支持项目自定义 key 命名风格警告。
+- 支持显式别名或符号归一化策略。
 
-## 诊断要求
+## 诊断信息
 
-诊断应使用结构化格式，并至少包含：
+当前重复 key 的错误消息会同时指出首次出现行和重复出现行。后续结构化诊断可进一步包含：
 
 - severity
 - file
@@ -106,32 +105,28 @@ DTGameConfig.GetValue<int>("MaxLevel");
 - errorCode
 - message
 
-重复 key 的错误消息应同时指出首次出现行和重复出现行，便于策划直接定位 Excel。
 
-## 二进制 payload 建议
+## 二进制 payload
 
-kv payload 可以采用确定性顺序写出：
+当前实现把 kv 字段转换为内部单行数据，复用现有表写出流程。后续如需独立 kv payload，可采用确定性顺序写出：
 
 1. 按 Excel 行顺序或按 key 排序写出条目；推荐默认保持 Excel 行顺序，便于诊断和 diff。
 2. 每个条目写出 key、类型签名和 value payload。
 3. 结构化 header 继续使用 v3 header、schema hash、generator version、table full name 和 flags。
 
-如果最终生成代码只使用强类型属性，运行时也应保留 key 到 value 的元数据，方便调试工具和兼容 API 查询。
+如果后续引入独立 kv payload，可保留 key 到 value 的元数据，方便调试工具和兼容 API 查询。
 
 ## 与索引和预热的关系
 
 - kv 表不需要普通行表索引；`Key` 本身就是唯一键。
-- kv 表应参与显式表注册和 `PreheatAsync`，以便服务端或客户端启动时提前校验配置。
-- 预热失败应暴露具体 key 和 value 解析错误，而不是只报告表加载失败。
+- kv 表可参与显式表注册和 `PreheatAsync`，以便服务端或客户端启动时提前加载配置。
+- 预热失败会暴露表加载失败；后续可增强为报告具体 key 和 value 解析错误。
 
-## 实现步骤建议
+## 后续实现建议
 
-1. 新增 `KvTableParser`，从固定列 `Key`、`Type`、`Value`、`Comment` 解析 kv schema。
-2. 新增 `KvTableValidator`，实现 key 唯一性、成员名、类型和值校验。
-3. 新增 kv serialization plan 或 writer，避免把 kv payload 写出逻辑放进 `DataTableProcessor`。
-4. 新增 kv 代码生成模板，输出强类型属性和可选动态访问 API。
-5. 为 `DTGen=kv` 注册 parser、validator、writer 和模板。
-6. 增加 kv 正常生成、重复 key、非法类型、非法 value、嵌套类型和 JSON 的测试。
+1. 新增更完整的 `KvTableValidator`，统一实现 value 解析诊断。
+2. 如有需要，新增 kv serialization plan 或 writer，避免未来把特殊 payload 写出逻辑放进 `DataTableProcessor`。
+3. 增加 kv 正常生成、重复 key、非法类型、非法 value、嵌套类型和 JSON 的测试。
 
 ## 非目标
 

--- a/docs/table-types.md
+++ b/docs/table-types.md
@@ -4,6 +4,8 @@
 
 ## 已支持类型
 
+当前代码中的默认解析器注册了 `table`、`matrix`、`column`、`kv`、`tree` 和 `graph`；代码模板也为这些类型提供生成器。
+
 ### `table`
 
 面向行的数据表。每一行数据都会生成一个行对象，并且可以参与索引构建。
@@ -34,13 +36,9 @@
 - 更便于编辑器填写的小型配置表
 - 字段较多、说明列较多或本地化列较多的小表
 
-## 预留原型类型
-
-解析器注册表会有意预留部分类型名称。这样项目使用尚未实现的表类型时，可以得到明确诊断，而不是静默回退到 `table` 语义。
-
 ### `kv`
 
-`kv` 计划用于全局参数、功能开关和少量散列配置。完整原型设计见 [kv 表类型设计](kv-table-design.md)。推荐 Excel 结构如下：
+`kv` 已支持用于全局参数、功能开关和少量散列配置。完整说明见 [kv 表类型设计](kv-table-design.md)。当前实现要求 `Key`、`Type`、`Value` 三列，并可选 `Comment` 列；每条配置会生成一行内部数据，生成表类会暴露同名静态属性以及动态读取 API。推荐 Excel 结构如下：
 
 | Key | Type | Value | Comment |
 | --- | --- | --- | --- |
@@ -49,31 +47,37 @@
 | DropRates | array<int> | 1,2,3 | 示例数组值 |
 | ExtraJson | json<GameConfig> | {"foo":1} | JSON 载荷 |
 
-计划生成的强类型 API 形态：
+已生成的强类型 API 形态：
 
 ```csharp
 DTGameConfig.MaxLevel
 DTGameConfig.EnablePvp
+DataTableManager.GetDataTable<DTGameConfig>()?.GetValue<int>("MaxLevel")
+DataTableManager.GetDataTable<DTGameConfig>()?.TryGetValue("EnablePvp", out bool? enablePvp)
 ```
 
-计划校验规则：
+当前校验与生成规则：
 
-- `Key` 必须唯一，并且必须是合法的生成成员名。
-- `Type` 复用普通字段的 DataTables 类型解析器。
-- `Value` 在写出 `.bytes` 前必须使用所选类型处理器完成校验。
-- 严格模式下，重复 key 和非法 value 应报告为生成错误；兼容模式可以把部分发现降级为警告。
-
-### `localized`
-
-`localized` 计划用于多语言文本资源。详细设计见 [localized 表类型设计](localized-table-design.md)。
+- `Key` 必须唯一，并且必须匹配合法 C# 成员名格式 `^[A-Za-z][A-Za-z0-9_]*$`。
+- `Type` 必填，并会复用普通字段的 DataTables 类型解析器做类型合法性检查。
+- `Value` 必填，并作为生成出的内部单行数据参与后续写出。
+- `Comment` 可选；存在时用作生成属性的 XML 摘要。
 
 ### `tree`
 
-`tree` 计划用于树形层级配置，例如章节、任务链、技能树和菜单结构。完整原型设计见 [tree 表类型设计](tree-table-design.md)。
+`tree` 已支持用于树形层级配置，例如章节、任务链、技能树和菜单结构。完整说明见 [tree 表类型设计](tree-table-design.md)。当前实现复用普通行表格式，要求 `Id` 和 `ParentId` 字段，并会内建 `Id` 唯一索引以及 `ParentId` 分组索引；生成表类会提供根节点、子节点、父节点和深度优先遍历 API。
 
 ### `graph`
 
 `graph` 已支持单 Sheet 边列表格式，用于节点与边组成的图结构配置，例如关卡拓扑、科技依赖、传送网络和状态机。必需字段为 `EdgeId`、`From` 和 `To`，生成器会内建 `EdgeId` 唯一索引以及 `From` / `To` 分组索引，并生成节点集合、边查询、入边/出边、关联边、前驱/后继、两点边、路径、BFS 遍历和节点存在性查询 API。完整说明见 [graph 表类型设计](graph-table-design.md)。
+
+## 预留原型类型
+
+解析器注册表会有意预留部分类型名称。这样项目使用尚未实现的表类型时，可以得到明确诊断，而不是静默回退到 `table` 语义。
+
+### `localized`
+
+`localized` 计划用于多语言文本资源，目前还不是已实现的表生成器。详细设计见 [localized 表类型设计](localized-table-design.md)。
 
 ### 其他预留名称
 

--- a/docs/tree-table-design.md
+++ b/docs/tree-table-design.md
@@ -1,14 +1,14 @@
 # tree 表类型设计
 
-`tree` 是计划中的树形配置表类型，适合表达有父子层级关系的数据，例如章节目录、任务链、技能树、菜单结构和组织结构。本文档仅描述原型设计；在实现完成前，当前生成器仍应对 `DTGen=tree` 给出“预留类型”诊断，而不是生成代码或数据。
+`tree` 是已实现的树形配置表类型，适合表达有父子层级关系的数据，例如章节目录、任务链、技能树、菜单结构和组织结构。当前生成器会解析 `DTGen=tree`，复用普通行表数据格式，并额外生成树查询 API。
 
 ## 目标
 
 - 用表格方式表达稳定的父子层级关系。
-- 在生成期发现孤儿节点、重复节点、循环引用和非法根节点。
+- 在生成期发现缺失必需字段、非法字段类型和普通行表可发现的数据错误；孤儿节点、循环引用和非法根节点校验可作为后续增强。
 - 生成强类型查询 API，支持按节点、父节点、子节点和根节点查询。
-- 支持客户端或服务端预热时提前校验完整树结构。
-- 通过注册 parser、validator、writer 和模板实现，不在 `DataTableProcessor` 主流程中硬编码 tree 分支。
+- 支持客户端或服务端通过预热提前加载树表；完整结构校验可作为后续增强。
+- 通过已注册的 parser 和模板实现，不在 `DataTableProcessor` 主流程中硬编码 tree 分支。
 
 ## 推荐 Excel 格式
 
@@ -22,8 +22,8 @@
 推荐约定：
 
 - `Id` 必填、唯一，并且作为树节点主键。
-- `ParentId` 为空表示根节点；非空时必须引用已存在的 `Id`。
-- `Order` 可选，用于同级节点排序；为空时按 Excel 行顺序排序。
+- `ParentId` 为空表示根节点；当前解析器会按 `ParentId` 建立分组索引，但不在解析阶段检查非空 `ParentId` 是否引用已存在的 `Id`。
+- `Order` 可选；字段类型留空时会默认为 `int`。当前生成的 `GetChildren` 返回分组索引顺序，不额外按 `Order` 排序。
 - `Name`、`Type`、`Payload` 为业务字段，可以按项目需要扩展。
 - `Comment` 可选，只用于说明，不进入运行时 payload。
 
@@ -43,45 +43,44 @@ DTGen=tree,class=QuestTree,namespace=Game.DataTables
 
 ## 生成代码形态
 
-推荐生成节点类型和树表查询 API：
+当前实现生成节点类型和树表查询 API：
 
 ```csharp
 var rootNodes = DTQuestTree.Roots;
 var node = DTQuestTree.GetById("Quest001");
-var children = DTQuestTree.GetChildren("Chapter01");
-var parent = DTQuestTree.GetParent("Quest001");
+var children = DTQuestTree.GetChildrenStatic("Chapter01");
+var parent = DTQuestTree.GetParentStatic("Quest001");
 DTQuestTree.TryGetById("Quest002", out var questNode);
 ```
 
-如果业务需要遍历，可以额外生成：
+当前实现也会生成深度优先遍历 API：
 
 ```csharp
-foreach (var node in DTQuestTree.TraverseDepthFirst("Root"))
+foreach (var node in DTQuestTree.TraverseDepthFirstStatic("Root"))
 {
     // visit node
 }
 ```
 
-## 校验规则
+## 当前校验规则
 
 ### 必须报错
 
-- `Id` 为空或重复。
-- `ParentId` 引用不存在的节点。
-- 任意节点形成循环引用。
-- 根节点数量不符合 Sheet 或项目配置要求。
-- `Order` 不是合法数字。
+- 缺少 `Id` 或 `ParentId` 字段。
+- `Id` 或 `ParentId` 显式声明为非 `string` 类型。
+- `Id` 重复会通过内建唯一索引写出/加载流程报错。
+- `Order` 存在且值不能按 `int` 或显式声明类型解析。
 - 业务字段不能按声明类型解析。
 
-### 可以警告
+### 后续可增强
 
-- 同一父节点下多个子节点 `Order` 相同。
-- 存在未被业务入口引用的孤立根节点，但配置允许多根。
-- 节点深度超过项目推荐上限。
+- 校验非空 `ParentId` 是否引用已存在的 `Id`。
+- 校验循环引用和根节点数量。
+- 对同一父节点下重复 `Order`、过深节点等输出项目级警告。
 
-## 诊断要求
+## 诊断信息
 
-结构化诊断至少应包含：
+后续结构化诊断可进一步包含：
 
 - severity
 - file
@@ -94,32 +93,29 @@ foreach (var node in DTQuestTree.TraverseDepthFirst("Root"))
 - errorCode
 - message
 
-循环引用诊断应输出完整路径，例如 `A -> B -> C -> A`，便于策划定位链路。
+如果后续实现循环引用校验，诊断应输出完整路径，例如 `A -> B -> C -> A`，便于策划定位链路。
 
-## 二进制 payload 建议
+## 二进制 payload
 
-推荐写出两类数据：
+当前实现复用普通行表 payload，并通过内建 `Id` 索引和 `ParentId` 分组索引支持树查询。后续如需独立树 payload，可写出两类数据：
 
 1. 节点顺序表：按 Excel 行顺序或稳定排序写出完整节点数据。
 2. 关系索引：写出 `Id -> index`、`ParentId -> child indexes` 和根节点索引列表。
 
-运行时加载时应能直接构建父子查询结构，避免每次查询都扫描全表。
+如果后续写出独立关系索引，运行时加载后即可直接构建父子查询结构，避免每次查询都扫描全表。
 
 ## 与索引和预热的关系
 
 - `Id` 是 tree 表的内建唯一索引。
 - `ParentId` 是内建分组索引。
-- tree 表应参与显式表注册和 `PreheatAsync`。
-- 预热失败应暴露节点 id、父节点 id 和循环路径等上下文。
+- tree 表可参与显式表注册和 `PreheatAsync`。
+- 当前预热失败会暴露表加载失败；后续可增强为报告节点 id、父节点 id 和循环路径等上下文。
 
-## 实现步骤建议
+## 后续实现建议
 
-1. 新增 `TreeTableParser`，识别固定列 `Id`、`ParentId`、`Order` 和业务字段。
-2. 新增 `TreeTableValidator`，实现唯一性、引用完整性和循环检测。
-3. 新增 tree serialization plan 或 writer，写出节点数据和关系索引。
-4. 新增 tree 代码生成模板，输出节点类型和树查询 API。
-5. 为 `DTGen=tree` 注册 parser、validator、writer 和模板。
-6. 增加正常树、多根树、孤儿节点、重复节点和循环引用测试。
+1. 新增更完整的 `TreeTableValidator`，实现引用完整性、循环检测和项目级根节点规则。
+2. 如有需要，新增 tree serialization plan 或 writer，写出节点数据和关系索引。
+3. 增加正常树、多根树、孤儿节点、重复节点和循环引用测试。
 
 ## 非目标
 


### PR DESCRIPTION
### Motivation

- The repository code registers and implements `table`, `matrix`, `column`, `kv`, `tree` and `graph` parsers and code templates, so the docs describing `kv` and `tree` as "planned" were stale and needed to reflect the actual implementation. 
- The docs previously described APIs and validation semantics that no longer match the code (for example static `DTGameConfig.*` access vs runtime `DataTableManager.GetDataTable<T>()` instance APIs). 

### Description

- Update `docs/table-types.md` to list the currently implemented DTGen types and move only truly-unimplemented types (`localized`, `partitioned`, `versioned`, `patch`) under reserved prototypes. 
- Revise `docs/kv-table-design.md` to describe the implemented `DTGen=kv` behavior including required columns (`Key`, `Type`, `Value`, optional `Comment`), the generated static properties and dynamic instance APIs, the `Key` naming requirement (`^[A-Za-z][A-Za-z0-9_]*$`), and current validation/write boundaries. 
- Revise `docs/tree-table-design.md` to describe the implemented `DTGen=tree` behavior (row-based format, required `Id`/`ParentId`, built-in `Id` unique index and `ParentId` grouping, generated tree query APIs including static accessors and depth-first traversal) and to clarify which structural checks are currently enforced versus planned as enhancements. 
- Small clarifications to show how to call dynamic `kv` APIs via `DataTableManager.GetDataTable<DTGameConfig>()` rather than assuming a top-level static accessor. 
- Modified files: `docs/table-types.md`, `docs/kv-table-design.md`, `docs/tree-table-design.md`.

### Testing

- Ran `git diff --check` and reviewed the generated diffs to ensure no trailing whitespace or obvious format issues. (succeeded)
- Searched documentation to ensure out-of-date phrases were removed with `rg` / pattern checks across `docs/` (succeeded). 
- Attempted to run `dotnet test --no-restore` but `dotnet` is not installed in the environment so unit tests were not executed (could not run).
- Changes have been staged and committed (`docs: update table type status`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba24125e483318c961e018d2e5e9a)