### PR TITLE
Add Unity runtime sync verification

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ChronosGames/Actions/.github/actions/setup-dotnet@main
       - run: dotnet build -c Debug
+      - run: ./scripts/verify-unity-runtime-sync.sh
+      - run: git diff --exit-code -- src/DataTables.Unity/Assets/Scripts/DataTables
       - run: dotnet test -c Debug --no-build
 
   build-unity:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: ChronosGames/Actions/.github/actions/setup-dotnet@main
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
+      - run: ./scripts/verify-unity-runtime-sync.sh
+      - run: git diff --exit-code -- src/DataTables.Unity/Assets/Scripts/DataTables
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
       - uses: ChronosGames/Actions/.github/actions/upload-artifact@main

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ DataTableManager.EnableProfiling(stats =>
    - 从[Releases](https://github.com/ChronosGames/DataTables/releases)下载`DataTables.Unity.unitypackage`
 
 2. **现代化Unity使用**
+
+> **运行时源码同步约定**：`src/DataTables` 是运行时源码的唯一修改源；`src/DataTables.Unity/Assets/Scripts/DataTables` 是构建 `src/DataTables/DataTables.csproj` 后自动同步出的 Unity 镜像目录。请不要直接修改 Unity 镜像中的 `.cs` 文件。提交前可运行 `dotnet build -c Debug`，再运行 `./scripts/verify-unity-runtime-sync.sh` 和 `git diff --exit-code -- src/DataTables.Unity/Assets/Scripts/DataTables`，确保 Unity 包与主运行时一致。
+
 ```csharp
 using DataTables;
 using UnityEngine;

--- a/scripts/verify-unity-runtime-sync.sh
+++ b/scripts/verify-unity-runtime-sync.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source_dir="$repo_root/src/DataTables"
+unity_dir="$repo_root/src/DataTables.Unity/Assets/Scripts/DataTables"
+
+if [[ ! -d "$source_dir" ]]; then
+  echo "Source directory not found: $source_dir" >&2
+  exit 1
+fi
+
+if [[ ! -d "$unity_dir" ]]; then
+  echo "Unity mirror directory not found: $unity_dir" >&2
+  exit 1
+fi
+
+tmp_source="$(mktemp)"
+tmp_unity="$(mktemp)"
+trap 'rm -f "$tmp_source" "$tmp_unity"' EXIT
+
+(
+  cd "$source_dir"
+  find . -type f -name '*.cs' \
+    ! -path './bin/*' \
+    ! -path './obj/*' \
+    ! -name '_InternalVisibleTo.cs' \
+    | sort
+) > "$tmp_source"
+
+(
+  cd "$unity_dir"
+  find . -type f -name '*.cs' | sort
+) > "$tmp_unity"
+
+if ! diff -u "$tmp_source" "$tmp_unity"; then
+  echo "Unity runtime mirror file list differs from src/DataTables." >&2
+  echo "Build src/DataTables to regenerate src/DataTables.Unity/Assets/Scripts/DataTables, then commit the synchronized files." >&2
+  exit 1
+fi
+
+while IFS= read -r relative_path; do
+  relative_path="${relative_path#./}"
+  if ! cmp -s "$source_dir/$relative_path" "$unity_dir/$relative_path"; then
+    echo "Unity runtime mirror content differs: $relative_path" >&2
+    echo "Source: $source_dir/$relative_path" >&2
+    echo "Unity : $unity_dir/$relative_path" >&2
+    exit 1
+  fi
+done < "$tmp_source"
+
+echo "Unity runtime mirror is synchronized with src/DataTables."

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
@@ -27,6 +27,11 @@ namespace DataTables
         public string FullName => Type.ToString();
 
         /// <summary>
+        /// 获取生成代码期望的数据表结构哈希。
+        /// </summary>
+        public virtual ulong SchemaHash => 0UL;
+
+        /// <summary>
         /// 获取数据表行的类型。
         /// </summary>
         public abstract Type Type

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/NetworkDataSource.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/NetworkDataSource.cs
@@ -27,7 +27,7 @@ namespace DataTables
             var url = $"{_baseUrl}/{name}.bytes";
             using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsByteArrayAsync();
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken);
         }
 
         public async ValueTask<bool> ExistsAsync(string name, CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- Prevent silent drift between `src/DataTables` (the canonical runtime sources) and the Unity mirror under `src/DataTables.Unity/Assets/Scripts/DataTables` by adding an automated consistency check. 
- Enforce synchronization as part of CI after building the main library so package releases and Unity packages cannot diverge from the primary runtime. 
- Make the repository convention explicit in documentation so contributors know the correct source-of-truth and how to validate sync before committing.

### Description
- Add `scripts/verify-unity-runtime-sync.sh` which compares the `.cs` file list and file contents between `src/DataTables` and `src/DataTables.Unity/Assets/Scripts/DataTables`, excluding build artifacts and `_InternalVisibleTo.cs`.
- Update `.github/workflows/build-debug.yml` and `.github/workflows/build-release.yml` to run the new script and `git diff --exit-code -- src/DataTables.Unity/Assets/Scripts/DataTables` immediately after `dotnet build` and before running tests.
- Update `README.md` to document the source-of-truth rule that `src/DataTables` is the only place to edit runtime sources and how to validate synchronization locally with the new script.
- Synchronize a couple of Unity-mirror files to match the main runtime: add a `SchemaHash` property to `DataTableBase` and make `NetworkDataSource.LoadAsync` pass the `cancellationToken` into `ReadAsByteArrayAsync`.

### Testing
- Ran `./scripts/verify-unity-runtime-sync.sh` locally and it completed successfully. 
- Ran `git diff --exit-code -- src/DataTables.Unity/Assets/Scripts/DataTables` after sync and it returned clean (no outstanding diffs).
- Performed a syntax check with `bash -n scripts/verify-unity-runtime-sync.sh` which passed. 
- Attempted `dotnet build -c Debug` in this environment but `dotnet` is not installed so that build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7922e408331a709dd6ca05cb4b0)