### PR TITLE
docs: make async README examples safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,25 @@ dotnet add package DataTables.API
 
 2. **零心智负担使用** 🎉
 ```csharp
+using System;
+using System.Threading.Tasks;
 using DataTables;
 
-// 🌟 现代异步API - 自动初始化
-var scene = await DataTableManager.LoadAsync<DTScene>();
-var items = DataTableManager.GetCached<DTItem>(); // 缓存查询
+public class Program
+{
+    public static async Task Main()
+    {
+        // 🌟 现代异步API - 自动初始化
+        var scene = await DataTableManager.LoadAsync<DTScene>();
+        var items = DataTableManager.GetCached<DTItem>(); // 缓存查询
 
-Console.WriteLine($"场景: {scene?.Name}, 物品数量: {items?.Count ?? 0}");
+        Console.WriteLine($"场景: {scene?.Name}, 物品数量: {items?.Count ?? 0}");
 
-// 🔥 可选的性能优化
-await DataTableManager.PreheatAsync(Priority.Critical | Priority.Normal);
-Console.WriteLine("数据预热完成！");
+        // 🔥 可选的性能优化
+        await DataTableManager.PreheatAsync(Priority.Critical | Priority.Normal);
+        Console.WriteLine("数据预热完成！");
+    }
+}
 ```
 
 3. **智能配置** (可选)
@@ -92,23 +100,32 @@ DataTableManager.EnableProfiling(stats =>
 
 2. **现代化Unity使用**
 ```csharp
+using System;
 using DataTables;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
+    // Unity生命周期入口允许 async void；请在方法内捕获异常，避免异常丢失。
     async void Start()
     {
-        // 🌟 异步优先 - 无阻塞启动
-        var config = await DataTableManager.LoadAsync<DTGameConfig>();
-        Debug.Log($"游戏版本: {config?.Version}");
+        try
+        {
+            // 🌟 异步优先 - 无阻塞启动
+            var config = await DataTableManager.LoadAsync<DTGameConfig>();
+            Debug.Log($"游戏版本: {config?.Version}");
 
-        // 🔥 智能分层预热
-        await DataTableManager.PreheatAsync(Priority.Critical);
-        Debug.Log("关键数据预热完成，游戏可以启动！");
+            // 🔥 智能分层预热
+            await DataTableManager.PreheatAsync(Priority.Critical);
+            Debug.Log("关键数据预热完成，游戏可以启动！");
 
-        // 后台预热其他数据
-        _ = DataTableManager.PreheatAsync(Priority.Normal | Priority.Lazy);
+            // 后台预热其他数据
+            _ = DataTableManager.PreheatAsync(Priority.Normal | Priority.Lazy);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
+        }
     }
 }
 ```
@@ -315,37 +332,59 @@ DataTableManager.ClearHooks();
 ### 现代Unity最佳实践
 
 ```csharp
+using System;
+using System.Threading.Tasks;
 using DataTables;
 using UnityEngine;
 
 public class ModernDataTableDemo : MonoBehaviour
 {
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-    static async void InitializeDataTables()
+    static void InitializeDataTables()
     {
-        // 🚀 启动时快速初始化
-        DataTableManager.UseFileSystem(Application.streamingAssetsPath + "/DataTables");
-        DataTableManager.EnableMemoryManagement(30); // Unity环境30MB限制
-
-        // 立即加载核心表
-        await DataTableManager.LoadAsync<DTGameConfig>();
-
-        // 后台预热其他表
-        _ = DataTableManager.PreheatAsync(Priority.Normal | Priority.Lazy);
+        _ = InitializeDataTablesAsync();
     }
 
+    static async Task InitializeDataTablesAsync()
+    {
+        try
+        {
+            // 🚀 启动时快速初始化
+            DataTableManager.UseFileSystem(Application.streamingAssetsPath + "/DataTables");
+            DataTableManager.EnableMemoryManagement(30); // Unity环境30MB限制
+
+            // 立即加载核心表
+            await DataTableManager.LoadAsync<DTGameConfig>();
+
+            // 后台预热其他表
+            _ = DataTableManager.PreheatAsync(Priority.Normal | Priority.Lazy);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
+        }
+    }
+
+    // Unity生命周期入口允许 async void；请在方法内捕获异常，避免异常丢失。
     async void Start()
     {
-        // 🎯 场景相关数据预热
-        await DataTableManager.PreheatAsync(Priority.Critical);
-        Debug.Log("关键数据已就绪，游戏可以开始！");
-
-        // 使用数据
-        var config = DataTableManager.GetCached<DTGameConfig>();
-        if (config != null)
+        try
         {
-            var gameConfig = DTGameConfig.GetDataRowById(1);
-            Debug.Log($"游戏版本: {gameConfig?.Version}");
+            // 🎯 场景相关数据预热
+            await DataTableManager.PreheatAsync(Priority.Critical);
+            Debug.Log("关键数据已就绪，游戏可以开始！");
+
+            // 使用数据
+            var config = DataTableManager.GetCached<DTGameConfig>();
+            if (config != null)
+            {
+                var gameConfig = DTGameConfig.GetDataRowById(1);
+                Debug.Log($"游戏版本: {gameConfig?.Version}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
         }
     }
 
@@ -363,6 +402,8 @@ public class ModernDataTableDemo : MonoBehaviour
 ### Unity性能优化技巧
 
 ```csharp
+using System.Threading.Tasks;
+
 // 📱 移动平台优化
 
 public class MobileOptimizationDemo : MonoBehaviour
@@ -384,8 +425,8 @@ public class MobileOptimizationDemo : MonoBehaviour
         DataTableManager.ClearCache();
     }
 
-    // 场景切换时的优化策略
-    public async void LoadScene(int sceneId)
+    // 场景切换时的优化策略：非Unity生命周期方法返回Task，便于调用方await并捕获异常。
+    public async Task LoadSceneAsync(int sceneId)
     {
         var sceneConfig = DTScene.GetDataRowById(sceneId);
 


### PR DESCRIPTION
### Motivation
- 避免 README 中向服务端或工具端用户错误示范 `async void` 导致不可等待和异常丢失的问题。 
- 保留 Unity 生命周期入口的 `async void` 场景，但明确其仅限于 Unity 生命周期并需处理异常。 

### Description
- 将 .NET 快速开始示例改为 `public static async Task Main()` 并加入必要的 `using System`、`using System.Threading.Tasks`。 
- 将 Unity 非生命周期初始化改为同步入口 `InitializeDataTables()` 转发到 `static async Task InitializeDataTablesAsync()`，并在异步方法中用 `try/catch` 捕获异常。 
- 在 `MonoBehaviour.Start()` 示例保留 `async void Start()`，但用 `try/catch` 包裹异步调用并增加注释说明仅限 Unity 生命周期入口。 
- 将非生命周期的场景加载方法从 `async void LoadScene` 改为可等待的 `public async Task LoadSceneAsync` 并调整示例导入 `using System.Threading.Tasks`。 

### Testing
- 运行 `git diff --check`，验证无格式/空格冲突，检查结果通过。 
- 使用 `rg -n "static async void|public async void|async void" README.md` 验证仅保留 Unity 生命周期的 `async void Start()` 实例且其他 `async void` 已被替换或改为 `Task`，检查结果符合预期。 
- 对修改后的 README 进行了本地文本替换与内容检查以确认示例编译/语义改动方向正确。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7d664d083319ce083c6ce815f3c)