### PR TITLE
Optimize data row insertion path — avoid per-row reflection

### DIFF
--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataMatrixBase.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataMatrixBase.cs
@@ -29,6 +29,8 @@ namespace DataTables
 
         public override bool ParseDataRow(int index, BinaryReader reader) => throw new NotSupportedException();
 
+        internal override void AddDataRow(int index, DataRowBase dataRow) => throw new NotSupportedException();
+
         protected void SetDataRow(int index, TKey1 key1, TKey2 key2, TValue value)
         {
             m_Keies1[index] = key1;

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTable.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTable.cs
@@ -309,7 +309,7 @@ namespace DataTables
 
         internal override void AddDataRow(int index, DataRowBase dataRow)
         {
-            InternalAddDataRow(index, (T)dataRow);
+            InternalAddDataRow(index, (T)(object)dataRow);
         }
 
         protected virtual void InternalAddDataRow(int index, T dataRow)

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTable.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTable.cs
@@ -307,6 +307,11 @@ namespace DataTables
         internal override void Shutdown()
         { }
 
+        internal override void AddDataRow(int index, DataRowBase dataRow)
+        {
+            InternalAddDataRow(index, (T)dataRow);
+        }
+
         protected virtual void InternalAddDataRow(int index, T dataRow)
         {
             m_DataSet[index] = dataRow;

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
@@ -51,6 +51,13 @@ namespace DataTables
         public abstract bool ParseDataRow(int index, BinaryReader reader);
 
         /// <summary>
+        /// 将已反序列化的数据行添加到指定索引。
+        /// </summary>
+        /// <param name="index">将要增加的数据表行的索引值。</param>
+        /// <param name="dataRow">已反序列化的数据行。</param>
+        internal abstract void AddDataRow(int index, DataRowBase dataRow);
+
+        /// <summary>
         /// 配置表加载完成
         /// <para>可重载该方法以便自定义一些额外的操作</para>
         /// </summary>

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableBase.cs
@@ -55,7 +55,7 @@ namespace DataTables
         /// </summary>
         /// <param name="index">将要增加的数据表行的索引值。</param>
         /// <param name="dataRow">已反序列化的数据行。</param>
-        internal abstract void AddDataRow(int index, DataRowBase dataRow);
+        internal virtual void AddDataRow(int index, DataRowBase dataRow) => throw new NotSupportedException();
 
         /// <summary>
         /// 配置表加载完成

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableManager.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataTableManager.cs
@@ -732,7 +732,7 @@ namespace DataTables
                     }
 
                     // 添加数据行到表中
-                    AddDataRowToTable(dataTable, i, dataRow);
+                    dataTable.AddDataRow(i, dataRow);
                 }
             }
 
@@ -806,20 +806,6 @@ namespace DataTables
             // 回退到反射模式（保持兼容性）
             var dataRowType = typeNamePair.Type.BaseType!.GetGenericArguments()[0];
             return (DataRowBase)Activator.CreateInstance(dataRowType)!;
-        }
-
-        /// <summary>
-        /// 添加数据行到表中 - 高性能内联
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AddDataRowToTable(DataTableBase dataTable, int index, DataRowBase dataRow)
-        {
-            // TODO: 将来使用预编译的委托（代码生成时实现）
-            // 暂时使用反射，但缓存方法信息
-            var tableType = dataTable.GetType();
-            var internalAddMethod = tableType.GetMethod("InternalAddDataRow",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            internalAddMethod?.Invoke(dataTable, new object[] { index, dataRow });
         }
 
         /// <summary>

--- a/src/DataTables/DataMatrixBase.cs
+++ b/src/DataTables/DataMatrixBase.cs
@@ -29,6 +29,8 @@ namespace DataTables
 
         public override bool ParseDataRow(int index, BinaryReader reader) => throw new NotSupportedException();
 
+        internal override void AddDataRow(int index, DataRowBase dataRow) => throw new NotSupportedException();
+
         protected void SetDataRow(int index, TKey1 key1, TKey2 key2, TValue value)
         {
             m_Keies1[index] = key1;

--- a/src/DataTables/DataTable.cs
+++ b/src/DataTables/DataTable.cs
@@ -309,7 +309,7 @@ namespace DataTables
 
         internal override void AddDataRow(int index, DataRowBase dataRow)
         {
-            InternalAddDataRow(index, (T)dataRow);
+            InternalAddDataRow(index, (T)(object)dataRow);
         }
 
         protected virtual void InternalAddDataRow(int index, T dataRow)

--- a/src/DataTables/DataTable.cs
+++ b/src/DataTables/DataTable.cs
@@ -307,6 +307,11 @@ namespace DataTables
         internal override void Shutdown()
         { }
 
+        internal override void AddDataRow(int index, DataRowBase dataRow)
+        {
+            InternalAddDataRow(index, (T)dataRow);
+        }
+
         protected virtual void InternalAddDataRow(int index, T dataRow)
         {
             m_DataSet[index] = dataRow;

--- a/src/DataTables/DataTableBase.cs
+++ b/src/DataTables/DataTableBase.cs
@@ -60,7 +60,7 @@ namespace DataTables
         /// </summary>
         /// <param name="index">将要增加的数据表行的索引值。</param>
         /// <param name="dataRow">已反序列化的数据行。</param>
-        internal abstract void AddDataRow(int index, DataRowBase dataRow);
+        internal virtual void AddDataRow(int index, DataRowBase dataRow) => throw new NotSupportedException();
 
         /// <summary>
         /// 配置表加载完成

--- a/src/DataTables/DataTableBase.cs
+++ b/src/DataTables/DataTableBase.cs
@@ -56,6 +56,13 @@ namespace DataTables
         public abstract bool ParseDataRow(int index, BinaryReader reader);
 
         /// <summary>
+        /// 将已反序列化的数据行添加到指定索引。
+        /// </summary>
+        /// <param name="index">将要增加的数据表行的索引值。</param>
+        /// <param name="dataRow">已反序列化的数据行。</param>
+        internal abstract void AddDataRow(int index, DataRowBase dataRow);
+
+        /// <summary>
         /// 配置表加载完成
         /// <para>可重载该方法以便自定义一些额外的操作</para>
         /// </summary>

--- a/src/DataTables/DataTableManager.cs
+++ b/src/DataTables/DataTableManager.cs
@@ -732,7 +732,7 @@ namespace DataTables
                     }
 
                     // 添加数据行到表中
-                    AddDataRowToTable(dataTable, i, dataRow);
+                    dataTable.AddDataRow(i, dataRow);
                 }
             }
 
@@ -806,20 +806,6 @@ namespace DataTables
             // 回退到反射模式（保持兼容性）
             var dataRowType = typeNamePair.Type.BaseType!.GetGenericArguments()[0];
             return (DataRowBase)Activator.CreateInstance(dataRowType)!;
-        }
-
-        /// <summary>
-        /// 添加数据行到表中 - 高性能内联
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AddDataRowToTable(DataTableBase dataTable, int index, DataRowBase dataRow)
-        {
-            // TODO: 将来使用预编译的委托（代码生成时实现）
-            // 暂时使用反射，但缓存方法信息
-            var tableType = dataTable.GetType();
-            var internalAddMethod = tableType.GetMethod("InternalAddDataRow",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            internalAddMethod?.Invoke(dataTable, new object[] { index, dataRow });
         }
 
         /// <summary>

--- a/tests/DataTables.Tests/PerformanceBenchmarkTest.cs
+++ b/tests/DataTables.Tests/PerformanceBenchmarkTest.cs
@@ -109,6 +109,57 @@ namespace DataTables.Tests
             Console.WriteLine($"内存使用: {memoryUsed / 1024}KB for 3 tables");
         }
 
+        /// <summary>
+        /// 基准测试：直接行添加路径应避免反射调用产生的逐行分配。
+        /// </summary>
+        [Fact]
+        public void DirectAddDataRow_Benchmark()
+        {
+            const int rowCount = 10_000;
+            var rows = Enumerable.Range(0, rowCount).Select(_ => new MockDataRow()).ToArray();
+            var directTable = new AddDataRowBenchmarkTable("direct", rowCount);
+            var reflectionTable = new AddDataRowBenchmarkTable("reflection", rowCount);
+            var internalAddMethod = typeof(AddDataRowBenchmarkTable).GetMethod(
+                "InternalAddDataRow",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+            // Warm up JIT and reflection metadata paths before measuring.
+            directTable.DirectAdd(0, rows[0]);
+            internalAddMethod.Invoke(reflectionTable, new object[] { 0, rows[0] });
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var directAllocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            var directStopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < rowCount; i++)
+            {
+                directTable.DirectAdd(i, rows[i]);
+            }
+            directStopwatch.Stop();
+            var directAllocated = GC.GetAllocatedBytesForCurrentThread() - directAllocatedBefore;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var reflectionAllocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            var reflectionStopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < rowCount; i++)
+            {
+                internalAddMethod.Invoke(reflectionTable, new object[] { i, rows[i] });
+            }
+            reflectionStopwatch.Stop();
+            var reflectionAllocated = GC.GetAllocatedBytesForCurrentThread() - reflectionAllocatedBefore;
+
+            directAllocated.Should().BeLessThan(reflectionAllocated);
+
+            Console.WriteLine(
+                $"行添加性能: direct={directStopwatch.ElapsedMilliseconds}ms/{directAllocated}B, " +
+                $"reflection={reflectionStopwatch.ElapsedMilliseconds}ms/{reflectionAllocated}B");
+        }
+
         private void ResetDataTableManager()
         {
             // 清理测试状态
@@ -160,6 +211,16 @@ namespace DataTables.Tests
             bw.Write(0);         // Flags
 
             return ms.ToArray();
+        }
+    }
+
+    public class AddDataRowBenchmarkTable : DataTable<MockDataRow>
+    {
+        public AddDataRowBenchmarkTable(string name, int capacity) : base(name, capacity) { }
+
+        public void DirectAdd(int index, MockDataRow dataRow)
+        {
+            InternalAddDataRow(index, dataRow);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Eliminate per-row reflection (`GetMethod(...)+Invoke`) during table load to reduce allocation and CPU overhead for large tables. 
- Provide a fast, direct insertion path that preserves the existing `InternalAddDataRow` extensibility point used by generated tables. 
- Add a micro-benchmark to demonstrate and guard the improvement and to serve as a regression test for future changes.

### Description

- Introduced an internal virtual dispatch on `DataTableBase`: `internal abstract void AddDataRow(int index, DataRowBase dataRow);` and implemented it in `DataTable<T>` to forward to `InternalAddDataRow` via a typed cast. 
- Made `DataMatrixBase` explicitly `AddDataRow`-unsupported by adding `internal override void AddDataRow(...) => throw new NotSupportedException();`. 
- Replaced the per-row reflection path in `DataTableManager` by calling `dataTable.AddDataRow(i, dataRow)` and removed the `AddDataRowToTable` reflection helper. 
- Mirrored the same API/behavior changes into the Unity copy under `src/DataTables.Unity/Assets/Scripts/DataTables`. 
- Added a benchmark-style test `DirectAddDataRow_Benchmark` and helper `AddDataRowBenchmarkTable` in `tests/DataTables.Tests/PerformanceBenchmarkTest.cs` that compares direct insertion against invoking the non-public `InternalAddDataRow` via reflection and asserts lower allocation for the direct path.

### Testing

- Ran repository searches to validate changes: `rg "AddDataRowToTable|GetMethod(\"InternalAddDataRow" -n src tests sandbox` and `rg "internal abstract void AddDataRow|internal override void AddDataRow|dataTable\.AddDataRow|DirectAddDataRow_Benchmark" -n src tests`, both verified the new callsites and signatures. 
- Performed `git diff --check` with no whitespace/merge issues reported. 
- Added and committed the changes locally; commit message: `Optimize data row insertion path`. 
- Attempted to run tests with `dotnet test tests/DataTables.Tests/DataTables.Tests.csproj --no-restore`, but the environment lacks `dotnet` so the test run could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7cb88e08331a537c98d69d55655)