### PR TITLE
Add HashValidatedDataSource and manifest hash policy

### DIFF
--- a/docs/data-source-pipeline.md
+++ b/docs/data-source-pipeline.md
@@ -11,8 +11,26 @@ DataTables 运行时采用**传输层处理优先**的模型：`IDataSource` 及
 | `Name` | 逻辑表名或资源名，不包含 `.bytes` 扩展名。 |
 | `Length` | 资源字节长度；未知时可为空。 |
 | `Version` | 单个资源版本；为空时可继承 manifest 级 `Version`。 |
-| `Hash` | 资源内容 hash，推荐使用小写 hex SHA-256。 |
+| `Hash` | 资源内容 hash，固定为解码后的 DataTables payload 的 SHA-256 小写 hex（64 字符）。 |
 | `SourceName` | 提供该条目的数据源诊断名，主要由 fallback 合并 manifest 时填充。 |
+
+## HashValidatedDataSource
+
+`HashValidatedDataSource` 是可选的 `IDataSource` 装饰器，用 manifest 条目的 `Hash` 在 `LoadAsync` 返回前校验 payload：
+
+- **算法与大小写**：固定为 SHA-256 lowercase hex，长度 64；大写 hex 或其他长度会被视为 manifest 格式错误。
+- **覆盖范围**：校验传入下一层运行时解析前的 DataTables payload。对于压缩/加密链路，应放在 `CompressedDataSource`、`EncryptedDataSource` 之后，以校验解压/解密后的明文字节；如需校验 CDN 原始传输包，可在外层另行增加传输包 hash。
+- **校验时机**：`LoadAsync` 从内部数据源取到字节后、返回给 `DataTableManager` 解析前立即校验，便于在热更新或 CDN 截断/污染时提前失败。
+- **未配置条目**：manifest 中没有对应 `Hash` 的资源会透传，不影响渐进接入。
+
+示例：
+
+```csharp
+var manifest = await cdn.GetManifestAsync(CancellationToken.None);
+IDataSource source = new HashValidatedDataSource(
+    new CompressedDataSource(cdn),
+    manifest);
+```
 
 ## VersionedDataSource
 
@@ -26,7 +44,8 @@ DataTables 运行时采用**传输层处理优先**的模型：`IDataSource` 及
 
 1. `ExistsAsync` 返回 `false` 时记录 `not found`。
 2. 加载异常时记录对应数据源和错误消息。
-3. 成功加载时更新 `LastHitSource`，方便日志和性能面板展示最终命中来源。
-4. 合并 manifest 时保留第一个出现的逻辑名，并把来源写入 `SourceName`。
+3. 成功加载时更新 `LastHitSource` 并写入 info 日志，方便日志和性能面板展示最终命中来源。
+4. 如果某个来源因为 hash 校验失败而抛出 `InvalidDataException`，会写入 warning 日志并继续尝试后续来源。
+5. 合并 manifest 时保留第一个出现的逻辑名，并把来源写入 `SourceName`。
 
 当所有数据源都失败时，抛出的 `FileNotFoundException` 会包含每个数据源的尝试结果，便于区分“本地缓存缺失”“远端不可用”和“资源损坏”。

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -106,6 +107,82 @@ namespace DataTables
         }
     }
 
+
+    public sealed class HashValidatedDataSource : DataSourceDecorator
+    {
+        public const string Algorithm = "SHA-256";
+        public const string HashFormat = "hex-lowercase";
+        private const int Sha256HexLength = 64;
+
+        private readonly IReadOnlyDictionary<string, DataSourceManifestEntry> _entries;
+
+        public HashValidatedDataSource(IDataSource inner, DataSourceManifest manifest) : base(inner)
+        {
+            if (manifest == null)
+            {
+                throw new ArgumentNullException(nameof(manifest));
+            }
+
+            _entries = manifest.Entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Hash))
+                .ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public HashValidatedDataSource(IDataSource inner, IEnumerable<DataSourceManifestEntry> entries) : base(inner)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+
+            _entries = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Hash))
+                .ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public override async ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken)
+        {
+            var bytes = await Inner.LoadAsync(name, cancellationToken);
+            if (!_entries.TryGetValue(name, out var entry))
+            {
+                return bytes;
+            }
+
+            ValidateHashFormat(entry);
+            var actual = ComputeSha256Hex(bytes);
+            if (!string.Equals(actual, entry.Hash, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Hash validation failed for '{name}' from '{entry.SourceName ?? Inner.ToString() ?? Inner.GetType().Name}': expected {entry.Hash}, actual {actual} ({Algorithm} {HashFormat}).");
+            }
+
+            return bytes;
+        }
+
+        private static void ValidateHashFormat(DataSourceManifestEntry entry)
+        {
+            var hash = entry.Hash!;
+            if (hash.Length != Sha256HexLength || hash.Any(ch => !IsLowerHex(ch)))
+            {
+                throw new InvalidDataException($"Manifest hash for '{entry.Name}' must be {Algorithm} {HashFormat} ({Sha256HexLength} chars). Actual: '{hash}'.");
+            }
+        }
+
+        private static bool IsLowerHex(char ch) => (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+
+        private static string ComputeSha256Hex(byte[] bytes)
+        {
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(bytes);
+            var builder = new StringBuilder(hash.Length * 2);
+            foreach (var b in hash)
+            {
+                builder.Append(b.ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+    }
+
     public sealed class FallbackDataSource : IDataSource
     {
         private readonly IReadOnlyList<IDataSource> _sources;
@@ -147,12 +224,18 @@ namespace DataTables
 
                     var bytes = await source.LoadAsync(name, cancellationToken);
                     LastHitSource = sourceName;
+                    Log.Info($"FallbackDataSource loaded '{name}' from {sourceName}.");
                     return bytes;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
+                    var failedSourceName = GetSourceName(source);
                     lastError = ex;
-                    failures.Add($"{GetSourceName(source)}: {ex.Message}");
+                    failures.Add($"{failedSourceName}: {ex.Message}");
+                    if (ex is InvalidDataException && ex.Message.IndexOf("hash", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        Log.Warning($"FallbackDataSource hash validation failed for '{name}' from {failedSourceName}: {ex.Message}");
+                    }
                 }
             }
 

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
@@ -93,6 +93,9 @@ namespace DataTables
 
         public string? Version { get; }
 
+        /// <summary>
+        /// 资源内容 hash。约定为解码后的 DataTables payload 的 SHA-256 小写 hex（64 字符）。
+        /// </summary>
         public string? Hash { get; }
 
         /// <summary>

--- a/src/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables/DataSourceDecorators.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -106,6 +107,82 @@ namespace DataTables
         }
     }
 
+
+    public sealed class HashValidatedDataSource : DataSourceDecorator
+    {
+        public const string Algorithm = "SHA-256";
+        public const string HashFormat = "hex-lowercase";
+        private const int Sha256HexLength = 64;
+
+        private readonly IReadOnlyDictionary<string, DataSourceManifestEntry> _entries;
+
+        public HashValidatedDataSource(IDataSource inner, DataSourceManifest manifest) : base(inner)
+        {
+            if (manifest == null)
+            {
+                throw new ArgumentNullException(nameof(manifest));
+            }
+
+            _entries = manifest.Entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Hash))
+                .ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public HashValidatedDataSource(IDataSource inner, IEnumerable<DataSourceManifestEntry> entries) : base(inner)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+
+            _entries = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Hash))
+                .ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public override async ValueTask<byte[]> LoadAsync(string name, CancellationToken cancellationToken)
+        {
+            var bytes = await Inner.LoadAsync(name, cancellationToken);
+            if (!_entries.TryGetValue(name, out var entry))
+            {
+                return bytes;
+            }
+
+            ValidateHashFormat(entry);
+            var actual = ComputeSha256Hex(bytes);
+            if (!string.Equals(actual, entry.Hash, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Hash validation failed for '{name}' from '{entry.SourceName ?? Inner.ToString() ?? Inner.GetType().Name}': expected {entry.Hash}, actual {actual} ({Algorithm} {HashFormat}).");
+            }
+
+            return bytes;
+        }
+
+        private static void ValidateHashFormat(DataSourceManifestEntry entry)
+        {
+            var hash = entry.Hash!;
+            if (hash.Length != Sha256HexLength || hash.Any(ch => !IsLowerHex(ch)))
+            {
+                throw new InvalidDataException($"Manifest hash for '{entry.Name}' must be {Algorithm} {HashFormat} ({Sha256HexLength} chars). Actual: '{hash}'.");
+            }
+        }
+
+        private static bool IsLowerHex(char ch) => (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+
+        private static string ComputeSha256Hex(byte[] bytes)
+        {
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(bytes);
+            var builder = new StringBuilder(hash.Length * 2);
+            foreach (var b in hash)
+            {
+                builder.Append(b.ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+    }
+
     public sealed class FallbackDataSource : IDataSource
     {
         private readonly IReadOnlyList<IDataSource> _sources;
@@ -147,12 +224,18 @@ namespace DataTables
 
                     var bytes = await source.LoadAsync(name, cancellationToken);
                     LastHitSource = sourceName;
+                    Log.Info($"FallbackDataSource loaded '{name}' from {sourceName}.");
                     return bytes;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
+                    var failedSourceName = GetSourceName(source);
                     lastError = ex;
-                    failures.Add($"{GetSourceName(source)}: {ex.Message}");
+                    failures.Add($"{failedSourceName}: {ex.Message}");
+                    if (ex is InvalidDataException && ex.Message.IndexOf("hash", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        Log.Warning($"FallbackDataSource hash validation failed for '{name}' from {failedSourceName}: {ex.Message}");
+                    }
                 }
             }
 

--- a/src/DataTables/IDataSource.cs
+++ b/src/DataTables/IDataSource.cs
@@ -93,6 +93,9 @@ namespace DataTables
 
         public string? Version { get; }
 
+        /// <summary>
+        /// 资源内容 hash。约定为解码后的 DataTables payload 的 SHA-256 小写 hex（64 字符）。
+        /// </summary>
         public string? Hash { get; }
 
         /// <summary>

--- a/tests/DataTables.Tests/DataSourcePipelineTests.cs
+++ b/tests/DataTables.Tests/DataSourcePipelineTests.cs
@@ -44,6 +44,39 @@ public class DataSourcePipelineTests
     }
 
     [Fact]
+    public async Task HashValidatedDataSource_Should_Verify_Decoded_Payload_Before_Returning()
+    {
+        var manifest = new DataSourceManifest(new[]
+        {
+            new DataSourceManifestEntry("Config", hash: "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81")
+        });
+        var source = new HashValidatedDataSource(new StubDataSource("cdn", true), manifest);
+
+        var bytes = await source.LoadAsync("Config", CancellationToken.None);
+
+        bytes.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task HashValidatedDataSource_Should_Reject_Mismatch_And_Uppercase_Hash()
+    {
+        var mismatch = new HashValidatedDataSource(
+            new StubDataSource("cdn", true),
+            new[] { new DataSourceManifestEntry("Config", hash: "139058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81") });
+        var uppercase = new HashValidatedDataSource(
+            new StubDataSource("cdn", true),
+            new[] { new DataSourceManifestEntry("Config", hash: "039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81") });
+
+        var mismatchAct = async () => await mismatch.LoadAsync("Config", CancellationToken.None);
+        var uppercaseAct = async () => await uppercase.LoadAsync("Config", CancellationToken.None);
+
+        await mismatchAct.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*Hash validation failed*");
+        await uppercaseAct.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*hex-lowercase*");
+    }
+
+    [Fact]
     public async Task VersionedDataSource_Should_Filter_And_Map_Manifest_To_Logical_Names()
     {
         var inner = new StubDataSource(


### PR DESCRIPTION
### Motivation
- Ensure manifest `Hash` is unambiguous and enforceable to detect CDN/Hotfix tampering early by fixing algorithm, format and validation timing. 
- Provide an opt-in IDataSource layer that verifies decoded DataTables payloads before they reach `DataTableManager` to fail fast on corruption.
- Improve fallback diagnostics so hash-validation failures are visible in logs and do not obscure other sources when falling back.

### Description
- Added `HashValidatedDataSource` decorator which validates payload bytes against manifest `Hash` entries using SHA-256 lowercase hex (64 chars) and throws `InvalidDataException` on mismatch or invalid hash format; it can be constructed from a `DataSourceManifest` or an enumerable of `DataSourceManifestEntry` and validates after decoding (i.e. should be placed after `CompressedDataSource`/`EncryptedDataSource`).
- Documented `DataSourceManifestEntry.Hash` as "decoded DataTables payload SHA-256 lowercase hex (64 characters)" in `IDataSource` and in `docs/data-source-pipeline.md` and added a new `HashValidatedDataSource` section explaining algorithm, scope and usage with an example `IDataSource` pipeline.
- Enhanced `FallbackDataSource` to set `LastHitSource` and emit an info log on successful load and to emit a warning log when a source fails due to hash validation while continuing to try subsequent sources.
- Added unit tests in `tests/DataTables.Tests/DataSourcePipelineTests.cs` for successful validation, hash mismatch rejection, and uppercase-hash rejection; and mirrored runtime changes into the Unity copy under `src/DataTables.Unity/Assets/Scripts/DataTables/`.

### Testing
- Ran `git diff --check` to validate workspace changes (passed).
- Attempted to run `dotnet test tests/DataTables.Tests/DataTables.Tests.csproj`, but `dotnet` is not available in the execution environment so the test suite was not executed here; the patch includes new xUnit tests that should be run in CI or a local environment with the .NET SDK installed.
- New tests added: `HashValidatedDataSource_Should_Verify_Decoded_Payload_Before_Returning` and `HashValidatedDataSource_Should_Reject_Mismatch_And_Uppercase_Hash` (not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7ef86b08331a263764a88478bd6)