### PR TITLE
Improve network data source availability checks

### DIFF
--- a/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/DataSourceDecorators.cs
@@ -29,7 +29,9 @@ namespace DataTables
 
         public virtual ValueTask<DataSourceManifest> GetManifestAsync(CancellationToken cancellationToken) => Inner.GetManifestAsync(cancellationToken);
 
-        public virtual ValueTask<bool> IsAvailableAsync() => Inner.IsAvailableAsync();
+        public virtual ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public virtual ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken) => Inner.IsAvailableAsync(cancellationToken);
     }
 
     public sealed class CachedDataSource : DataSourceDecorator
@@ -198,11 +200,14 @@ namespace DataTables
             return $"{source.SourceType}:{displayName}";
         }
 
-        public async ValueTask<bool> IsAvailableAsync()
+        public ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public async ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
         {
             foreach (var source in _sources)
             {
-                if (await source.IsAvailableAsync())
+                cancellationToken.ThrowIfCancellationRequested();
+                if (await source.IsAvailableAsync(cancellationToken))
                 {
                     return true;
                 }

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/IDataSource.cs
@@ -47,7 +47,16 @@ namespace DataTables
         /// 检查数据源是否可用。
         /// </summary>
         /// <returns>是否可用。</returns>
-        ValueTask<bool> IsAvailableAsync();
+        ValueTask<bool> IsAvailableAsync()
+            => IsAvailableAsync(CancellationToken.None);
+
+        /// <summary>
+        /// 检查数据源是否可用。
+        /// </summary>
+        /// <param name="cancellationToken">取消令牌。</param>
+        /// <returns>是否可用。</returns>
+        ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
+            => IsAvailableAsync();
 
         /// <summary>
         /// 数据源类型。

--- a/src/DataTables.Unity/Assets/Scripts/DataTables/NetworkDataSource.cs
+++ b/src/DataTables.Unity/Assets/Scripts/DataTables/NetworkDataSource.cs
@@ -10,12 +10,24 @@ namespace DataTables
     /// </summary>
     public class NetworkDataSource : IDataSource
     {
+        private static readonly TimeSpan DefaultAvailabilityTimeout = TimeSpan.FromSeconds(5);
         private readonly string _baseUrl;
-        private static readonly HttpClient _httpClient = new();
+        private readonly string? _availabilityResourceName;
+        private readonly TimeSpan _availabilityTimeout;
+        private readonly HttpClient _httpClient;
+        private static readonly HttpClient s_sharedHttpClient = new();
 
         public NetworkDataSource(string baseUrl)
+            : this(baseUrl, availabilityResourceName: "manifest.json")
+        {
+        }
+
+        public NetworkDataSource(string baseUrl, string? availabilityResourceName, TimeSpan? availabilityTimeout = null, HttpClient? httpClient = null)
         {
             _baseUrl = baseUrl?.TrimEnd('/') ?? throw new ArgumentNullException(nameof(baseUrl));
+            _availabilityResourceName = string.IsNullOrWhiteSpace(availabilityResourceName) ? null : availabilityResourceName.TrimStart('/');
+            _availabilityTimeout = availabilityTimeout ?? DefaultAvailabilityTimeout;
+            _httpClient = httpClient ?? s_sharedHttpClient;
         }
 
         public DataSourceType SourceType => DataSourceType.Network;
@@ -38,17 +50,36 @@ namespace DataTables
             return response.IsSuccessStatusCode;
         }
 
-        public async ValueTask<bool> IsAvailableAsync()
+        public ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public async ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
         {
             try
             {
-                var response = await _httpClient.GetAsync(_baseUrl, HttpCompletionOption.ResponseHeadersRead);
-                return response.IsSuccessStatusCode;
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(_availabilityTimeout);
+                var token = timeoutCts.Token;
+                var url = GetAvailabilityUrl();
+
+                using var headRequest = new HttpRequestMessage(HttpMethod.Head, url);
+                using var headResponse = await _httpClient.SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, token);
+                if (headResponse.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+
+                using var getResponse = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
+                return getResponse.IsSuccessStatusCode;
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 return false;
             }
+        }
+
+        private string GetAvailabilityUrl()
+        {
+            return _availabilityResourceName == null ? _baseUrl : $"{_baseUrl}/{_availabilityResourceName}";
         }
     }
 }

--- a/src/DataTables/DataSourceDecorators.cs
+++ b/src/DataTables/DataSourceDecorators.cs
@@ -29,7 +29,9 @@ namespace DataTables
 
         public virtual ValueTask<DataSourceManifest> GetManifestAsync(CancellationToken cancellationToken) => Inner.GetManifestAsync(cancellationToken);
 
-        public virtual ValueTask<bool> IsAvailableAsync() => Inner.IsAvailableAsync();
+        public virtual ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public virtual ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken) => Inner.IsAvailableAsync(cancellationToken);
     }
 
     public sealed class CachedDataSource : DataSourceDecorator
@@ -198,11 +200,14 @@ namespace DataTables
             return $"{source.SourceType}:{displayName}";
         }
 
-        public async ValueTask<bool> IsAvailableAsync()
+        public ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public async ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
         {
             foreach (var source in _sources)
             {
-                if (await source.IsAvailableAsync())
+                cancellationToken.ThrowIfCancellationRequested();
+                if (await source.IsAvailableAsync(cancellationToken))
                 {
                     return true;
                 }

--- a/src/DataTables/IDataSource.cs
+++ b/src/DataTables/IDataSource.cs
@@ -47,7 +47,16 @@ namespace DataTables
         /// 检查数据源是否可用。
         /// </summary>
         /// <returns>是否可用。</returns>
-        ValueTask<bool> IsAvailableAsync();
+        ValueTask<bool> IsAvailableAsync()
+            => IsAvailableAsync(CancellationToken.None);
+
+        /// <summary>
+        /// 检查数据源是否可用。
+        /// </summary>
+        /// <param name="cancellationToken">取消令牌。</param>
+        /// <returns>是否可用。</returns>
+        ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
+            => IsAvailableAsync();
 
         /// <summary>
         /// 数据源类型。

--- a/src/DataTables/NetworkDataSource.cs
+++ b/src/DataTables/NetworkDataSource.cs
@@ -10,12 +10,24 @@ namespace DataTables
     /// </summary>
     public class NetworkDataSource : IDataSource
     {
+        private static readonly TimeSpan DefaultAvailabilityTimeout = TimeSpan.FromSeconds(5);
         private readonly string _baseUrl;
-        private static readonly HttpClient _httpClient = new();
+        private readonly string? _availabilityResourceName;
+        private readonly TimeSpan _availabilityTimeout;
+        private readonly HttpClient _httpClient;
+        private static readonly HttpClient s_sharedHttpClient = new();
 
         public NetworkDataSource(string baseUrl)
+            : this(baseUrl, availabilityResourceName: "manifest.json")
+        {
+        }
+
+        public NetworkDataSource(string baseUrl, string? availabilityResourceName, TimeSpan? availabilityTimeout = null, HttpClient? httpClient = null)
         {
             _baseUrl = baseUrl?.TrimEnd('/') ?? throw new ArgumentNullException(nameof(baseUrl));
+            _availabilityResourceName = string.IsNullOrWhiteSpace(availabilityResourceName) ? null : availabilityResourceName.TrimStart('/');
+            _availabilityTimeout = availabilityTimeout ?? DefaultAvailabilityTimeout;
+            _httpClient = httpClient ?? s_sharedHttpClient;
         }
 
         public DataSourceType SourceType => DataSourceType.Network;
@@ -38,17 +50,36 @@ namespace DataTables
             return response.IsSuccessStatusCode;
         }
 
-        public async ValueTask<bool> IsAvailableAsync()
+        public ValueTask<bool> IsAvailableAsync() => IsAvailableAsync(CancellationToken.None);
+
+        public async ValueTask<bool> IsAvailableAsync(CancellationToken cancellationToken)
         {
             try
             {
-                var response = await _httpClient.GetAsync(_baseUrl, HttpCompletionOption.ResponseHeadersRead);
-                return response.IsSuccessStatusCode;
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(_availabilityTimeout);
+                var token = timeoutCts.Token;
+                var url = GetAvailabilityUrl();
+
+                using var headRequest = new HttpRequestMessage(HttpMethod.Head, url);
+                using var headResponse = await _httpClient.SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, token);
+                if (headResponse.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+
+                using var getResponse = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
+                return getResponse.IsSuccessStatusCode;
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 return false;
             }
+        }
+
+        private string GetAvailabilityUrl()
+        {
+            return _availabilityResourceName == null ? _baseUrl : $"{_baseUrl}/{_availabilityResourceName}";
         }
     }
 }

--- a/tests/DataTables.Tests/DataSourcePipelineTests.cs
+++ b/tests/DataTables.Tests/DataSourcePipelineTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DataTables;
@@ -63,6 +65,44 @@ public class DataSourcePipelineTests
         manifest.Entries.Single(entry => entry.Name == "Item").Version.Should().Be("v2.1");
     }
 
+    [Fact]
+    public async Task NetworkDataSource_IsAvailableAsync_Should_Probe_Manifest_With_Head_Then_Get_Fallback()
+    {
+        var handler = new RecordingHandler(request => request.Method == HttpMethod.Head
+            ? new HttpResponseMessage(HttpStatusCode.MethodNotAllowed)
+            : new HttpResponseMessage(HttpStatusCode.OK));
+        var source = new NetworkDataSource(
+            "https://cdn.example.com/data/",
+            "health.txt",
+            TimeSpan.FromSeconds(1),
+            new HttpClient(handler));
+
+        var available = await source.IsAvailableAsync(CancellationToken.None);
+
+        available.Should().BeTrue();
+        handler.Requests.Select(request => (request.Method, request.RequestUri!.ToString())).Should().Equal(
+            (HttpMethod.Head, "https://cdn.example.com/data/health.txt"),
+            (HttpMethod.Get, "https://cdn.example.com/data/health.txt"));
+    }
+
+    [Fact]
+    public async Task NetworkDataSource_IsAvailableAsync_Should_Respect_CancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var source = new NetworkDataSource(
+            "https://cdn.example.com/data",
+            "manifest.json",
+            TimeSpan.FromSeconds(1),
+            new HttpClient(handler));
+
+        var act = async () => await source.IsAvailableAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        handler.Requests.Should().BeEmpty();
+    }
+
     private sealed class StubDataSource : IDataSource
     {
         private readonly string _name;
@@ -102,5 +142,24 @@ public class DataSourcePipelineTests
         public ValueTask<bool> IsAvailableAsync() => new ValueTask<bool>(true);
 
         public override string ToString() => _name;
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(_responseFactory(request));
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- `NetworkDataSource.IsAvailableAsync` previously performed an uncontrolled GET to the base URL without a `CancellationToken`, timeout, or a health/manifest target which can cause slow startup or false negatives for CDNs that deny directory GETs. 
- Availability checks in the data-source pipeline did not accept cancellation tokens, so callers could not abort slow probes or propagate timeouts. 
- Provide a safer, configurable probe that prefers a small health/manifest resource and falls back to `GET` when `HEAD` is not supported.

### Description
- Add a cancellable availability API by introducing `IsAvailableAsync(CancellationToken)` on `IDataSource` while preserving the parameterless overload. 
- Update decorators and composite/fallback sources to forward the `CancellationToken`, call the cancellable overload, and stop probing when cancellation is requested. 
- Revamp `NetworkDataSource` with new constructors that accept an `availabilityResourceName`, optional `availabilityTimeout`, and optional `HttpClient`; default resource is `manifest.json` and default timeout is 5 seconds. 
- Implement availability probing that creates a linked `CancellationTokenSource` with the timeout, probes the configured availability URL with `HEAD` first and then falls back to `GET` if `HEAD` does not succeed, and respects cancellation. 
- Mirror the same changes into the Unity source copy and add unit tests that exercise `HEAD`→`GET` fallback and cancellation behavior; add a small `RecordingHandler` test helper to assert requests.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff hygiene and it passed. 
- Added two unit tests in `tests/DataTables.Tests/DataSourcePipelineTests.cs` covering the `HEAD`→`GET` fallback and cancellation semantics, but `dotnet test` could not be executed in the environment because `dotnet` is not installed, so test execution was not performed here. 
- No failing automated checks were produced by the local validation steps available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7bffdac8331a27ae87aad1f47ea)