### PR TITLE
docs: 在阶段 C 冻结 graph 表生成 API、索引与校验规范

### DIFF
--- a/docs/optimization-plan-2026-07.md
+++ b/docs/optimization-plan-2026-07.md
@@ -264,6 +264,40 @@ DTGameConfig.EnablePvp
 
 - 设计文档明确格式、生成代码形态、运行时查询 API。
 
+#### C4. 冻结 `graph` 表生成 API、索引约束与校验规范
+
+背景设计参考：`docs/graph-table-design.md`。在进入实现前，需要先冻结 `graph` 表的生成 API、索引约束与校验规范，避免 parser、validator、template 与文档在后续实现中各自演进。
+
+需要确认的生成 API：
+
+- 节点集合查询。
+- 出边、入边、关联边查询。
+- 前驱、后继、邻居查询。
+- 两点边查询。
+- `HasEdge` / `HasPath`。
+- `FindPath`。
+- BFS 遍历。
+- `TryGetEdge` / edge id 查询。
+
+需要确认的索引约束：
+
+- `EdgeId` 为内建唯一索引。
+- `From` / `To` 为分组索引。
+- 节点集合是否始终由 `From` / `To` 自动推导。
+
+需要确认的校验规则：
+
+- `EdgeId`、`From`、`To` 不能为空。
+- `EdgeId` 不能重复。
+- `Weight` 字段如存在必须可解析为数字。
+- 是否允许自环、重边、孤立节点、无向图语义。
+
+**验收标准：**
+
+- API 命名和返回类型在实现前冻结。
+- 文档、parser、validator、template 的行为一致。
+- 后续实现不得在 `DataTableProcessor` 主流程中继续追加 graph 专用分支。
+
 ### 阶段 D：文档、测试与开发体验（优先级 P1/P2）
 
 #### D1. 文档拆分


### PR DESCRIPTION
### Motivation

- 在进入实现前需要冻结 `graph` 表的生成 API、内建索引约束与校验规则，以避免 `parser`、`validator`、`template` 与文档在后续实现中各自演进。
- 目标是确保文档、生成器与运行时行为一致，并禁止在 `DataTableProcessor` 主流程中追加 graph 专用分支。

### Description

- 修改了 `docs/optimization-plan-2026-07.md`，在阶段 C（Milestone 3）新增 `C4` 条目以提出并冻结 `graph` 表规范要点。
- 在新增条目中列出需要确认的生成 API（节点集合查询、出/入/关联边查询、前驱/后继/邻居查询、两点边查询、`HasEdge`/`HasPath`、`FindPath`、BFS、`TryGetEdge`/edge id 查询）。
- 指明需要确认的索引约束（`EdgeId` 内建唯一索引、`From`/`To` 分组索引、节点集合是否由 `From`/`To` 自动推导）和校验规则（`EdgeId`/`From`/`To` 非空、`EdgeId` 唯一、`Weight` 必须可解析为数字、是否允许自环/重边/孤立节点/无向语义）。
- 增加验收标准，要求在实现前冻结 API 命名与返回类型，确保文档、`parser`、`validator`、`template` 行为一致，并禁止在 `DataTableProcessor` 主流程继续添加 graph 专用分支，且引用了 `docs/graph-table-design.md` 作为背景设计。

### Testing

- 运行了自动检查 `git diff --check`，结果通过（无格式/空白错误）。
- 使用 `git status --short` 验证工作区状态为已提交变更。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc90e84808331aa9ce7a0c4cae958)